### PR TITLE
nbmake version bump

### DIFF
--- a/test_environment.yml
+++ b/test_environment.yml
@@ -9,6 +9,6 @@ dependencies:
 - matplotlib==3.5.2
 - imagemagick==7.1.0_36
 - pytest==7.1.2
-- nbmake==1.3.0
+- nbmake==1.3.3
 - jupytext==1.13.8
 - jupyter==1.0.0


### PR DESCRIPTION
Upgrade the nbmake version to omit the current warning.