### PR TITLE
Add Visualization Tutorials

### DIFF
--- a/tutorials-v4/visualization/JC-model-wigner-function.md
+++ b/tutorials-v4/visualization/JC-model-wigner-function.md
@@ -1,0 +1,163 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernel_info:
+    name: python3
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+ QuTiP example: Wigner function animation for the dynamics of the Jaynes-Cumming model
+
+
+J.R. Johansson and P.D. Nation
+
+For more information about QuTiP see [http://qutip.org](http://qutip.org)
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import cm
+from mpl_toolkits.mplot3d import Axes3D
+from qutip import about, basis, destroy, mesolve, ptrace, qeye, tensor, wigner
+from qutip.ipynbtools import plot_animation
+
+%matplotlib inline
+```
+
+```python
+def jc_integrate(N, wc, wa, g, kappa, gamma, psi0, use_rwa, tlist):
+
+    # Hamiltonian
+    idc = qeye(N)
+    ida = qeye(2)
+
+    a = tensor(destroy(N), ida)
+    sm = tensor(idc, destroy(2))
+
+    if use_rwa:
+        # use the rotating wave approxiation
+        H = wc * a.dag() * a + wa * sm.dag() * sm + \
+            g * (a.dag() * sm + a * sm.dag())
+    else:
+        H = wc * a.dag() * a + wa * sm.dag() * sm + \
+            g * (a.dag() + a) * (sm + sm.dag())
+
+    # collapse operators
+    c_op_list = []
+
+    n_th_a = 0.0  # zero temperature
+
+    rate = kappa * (1 + n_th_a)
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * a)
+
+    rate = kappa * n_th_a
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * a.dag())
+
+    rate = gamma
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * sm)
+
+    # evolve and calculate return state vectors
+    result = mesolve(H, psi0, tlist, c_op_list, [])
+
+    return result
+```
+
+```python
+# parameters
+wc = 1.0 * 2 * np.pi  # cavity frequency
+wa = 1.0 * 2 * np.pi  # atom frequency
+g = 0.05 * 2 * np.pi  # coupling strength
+kappa = 0.05  # cavity dissipation rate
+gamma = 0.15  # atom dissipation rate
+N = 10  # number of cavity fock states
+
+use_rwa = True
+
+# start with an excited atom
+psi0 = tensor(basis(N, 0), basis(2, 1))
+# or a coherent state the in cavity
+# psi0 = tensor(coherent(N,1.5), basis(2,0))
+# or a superposition of coherent states
+# psi0 = tensor((coherent(N,2.0)+coherent(N,-2.0)).unit(), basis(2,0))
+
+tlist = np.linspace(0, 30, 150)
+```
+
+```python
+result = jc_integrate(N, wc, wa, g, kappa, gamma, psi0, use_rwa, tlist)
+```
+
+```python
+xvec = np.linspace(-5.0, 5.0, 100)
+X, Y = np.meshgrid(xvec, xvec)
+```
+
+```python
+def plot_setup(result):
+
+    fig = plt.figure(figsize=(12, 6))
+    ax = Axes3D(fig, azim=-107, elev=49)
+
+    return fig, ax
+```
+
+```python
+cb = None
+
+
+def plot_result(result, n, fig=None, axes=None):
+
+    global cb
+
+    if fig is None or axes is None:
+        fig, ax = plot_setup(result)
+
+    axes.cla()
+
+    # trace out the atom
+    rho_cavity = ptrace(result.states[n], 0)
+
+    W = wigner(rho_cavity, xvec, xvec)
+
+    surf = axes.plot_surface(
+        X,
+        Y,
+        W,
+        rstride=1,
+        cstride=1,
+        cmap=cm.jet,
+        alpha=1.0,
+        linewidth=0.05,
+        vmax=0.25,
+        vmin=-0.25,
+    )
+    axes.set_xlim3d(-5, 5)
+    axes.set_ylim3d(-5, 5)
+    axes.set_zlim3d(-0.25, 0.25)
+
+    if not cb:
+        cb = plt.colorbar(surf, shrink=0.65, aspect=20)
+
+    return axes.artists
+```
+
+```python
+plot_animation(plot_setup, plot_result, result, writer="ffmpeg", codec=None)
+```
+
+# Versions
+
+```python
+about()
+```

--- a/tutorials-v4/visualization/bloch-sphere-animation.md
+++ b/tutorials-v4/visualization/bloch-sphere-animation.md
@@ -1,0 +1,130 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# QuTiP example: Bloch sphere animation
+
+
+J.R. Johansson and P.D. Nation
+
+For more information about QuTiP see [http://qutip.org](http://qutip.org)
+
+
+Animation with qutip and matplotlib: decaying qubit visualized in a Bloch sphere.
+(Animation with matplotlib does not work yet in python3)
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from mpl_toolkits.mplot3d import Axes3D
+from qutip import Bloch, about, basis, mesolve, sigmam, sigmax, sigmay, sigmaz
+from qutip.ipynbtools import plot_animation
+
+%matplotlib inline
+```
+
+```python
+def qubit_integrate(w, theta, gamma1, gamma2, psi0, tlist):
+    # operators and the hamiltonian
+    sx = sigmax()
+    sy = sigmay()
+    sz = sigmaz()
+    sm = sigmam()
+    H = w * (np.cos(theta) * sz + np.sin(theta) * sx)
+    # collapse operators
+    c_op_list = []
+    n_th = 0.5  # temperature
+    rate = gamma1 * (n_th + 1)
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * sm)
+    rate = gamma1 * n_th
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * sm.dag())
+    rate = gamma2
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * sz)
+
+    # evolve and calculate expectation values
+    output = mesolve(H, psi0, tlist, c_op_list, [sx, sy, sz])
+    return output
+```
+
+```python
+w = 1.0 * 2 * np.pi  # qubit angular frequency
+theta = 0.2 * np.pi  # qubit angle from sigma_z axis (toward sigma_x axis)
+gamma1 = 0.5  # qubit relaxation rate
+gamma2 = 0.2  # qubit dephasing rate
+# initial state
+a = 1.0
+psi0 = (a * basis(2, 0) + (1 - a) * basis(2, 1)) / \
+        (np.sqrt(a**2 + (1 - a) ** 2))
+tlist = np.linspace(0, 4, 150)
+```
+
+```python
+result = qubit_integrate(w, theta, gamma1, gamma2, psi0, tlist)
+```
+
+```python
+def plot_setup(result):
+
+    fig = plt.figure(figsize=(8, 8))
+    axes = Axes3D(fig, azim=-40, elev=30)
+
+    return fig, axes
+```
+
+```python
+sphere = None
+
+
+def plot_result(result, n, fig=None, axes=None):
+
+    global sphere
+
+    if fig is None or axes is None:
+        fig, axes = plot_setup(result)
+
+    if not sphere:
+        sphere = Bloch(axes=axes)
+        sphere.vector_color = ["r"]
+
+    sphere.clear()
+    sphere.add_vectors([result.expect[0][n],
+                        result.expect[1][n],
+                        result.expect[2][n]])
+    sphere.add_points(
+        [
+            result.expect[0][: n + 1],
+            result.expect[1][: n + 1],
+            result.expect[2][: n + 1],
+        ],
+        meth="l",
+    )
+    sphere.make_sphere()
+
+    return axes.artists
+```
+
+```python
+# You can choose your own writer and codec here.
+# Setting codec=None sets the codec to the standard
+# defined in matplotlib.rcParams['animation.codec']
+plot_animation(plot_setup, plot_result, result, writer="ffmpeg", codec=None)
+```
+
+## Versions
+
+```python
+about()
+```

--- a/tutorials-v4/visualization/bloch_sphere_with_colorbar.md
+++ b/tutorials-v4/visualization/bloch_sphere_with_colorbar.md
@@ -1,0 +1,92 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# Adding a colorbar to a Bloch Sphere
+
+```python
+import matplotlib as mpl
+import numpy as np
+from matplotlib import cm
+from qutip import Bloch, about, basis, destroy, sesolve, sigmax, sigmay, sigmaz
+
+%matplotlib inline
+```
+
+## Do a closed Landau-Zener Evolution
+
+```python
+delta = 0.5 * 2 * np.pi
+v = 2.0 * 2 * np.pi  # sweep rate
+
+H0 = delta / 2.0 * sigmax()
+H1 = v / 2.0 * sigmaz()
+H = [H0, [H1, "t"]]
+psi0 = basis(2, 0)
+
+sm = destroy(2)
+sx = sigmax()
+sy = sigmay()
+sz = sigmaz()
+expt_ops = [sm.dag() * sm, sx, sy, sz]
+
+
+tlist = np.linspace(-10.0, 10.0, 1500)
+expt_list = sesolve(H, psi0, tlist, expt_ops).expect
+```
+
+## Generate a Bloch Sphere with Multi-Colored Points
+
+
+Note that I need to call `b.show` here so that I can grab a Figure instance later
+
+```python
+b = Bloch()
+# normalize colors to times in tlist ##
+nrm = mpl.colors.Normalize(-2, 10)
+colors = cm.cool(nrm(tlist))
+
+# add data points from expectation values ##
+b.add_points([expt_list[1], expt_list[2], -expt_list[3]], "m")
+
+# customize sphere properties ##
+b.point_color = list(colors)
+b.point_marker = ["o"]
+b.point_size = [20]
+
+b.zlpos = [1.1, -1.2]
+
+b.show()
+```
+
+## Add  New Axis to Bloch Figure
+
+```python
+left, bottom, width, height = [0.98, 0.05, 0.05, 0.9]
+ax2 = b.fig.add_axes([left, bottom, width, height])
+
+mpl.colorbar.ColorbarBase(ax2, cmap=cm.cool, norm=nrm, orientation="vertical");
+```
+
+## Plot with Colorbar Added
+
+
+Currently I need to call `b.fig` as replotting figures in a notebook is a bit tricky.  However, this is likely to be improved in the future.
+
+```python
+b.fig
+```
+
+```python
+about()
+```

--- a/tutorials-v4/visualization/energy-levels.md
+++ b/tutorials-v4/visualization/energy-levels.md
@@ -1,0 +1,93 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# QuTiP example: Energy-levels of a quantum systems as a function of a single parameter
+
+
+J.R. Johansson and P.D. Nation
+
+For more information about QuTiP see [http://qutip.org](http://qutip.org)
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from numpy import pi
+from qutip import about, qeye, sigmax, sigmaz, tensor
+
+%matplotlib inline
+```
+
+## Energy spectrum of three coupled qubits
+
+```python
+def compute(w1list, w2, w3, g12, g13):
+
+    # Pre-compute operators for the hamiltonian
+    sz1 = tensor(sigmaz(), qeye(2), qeye(2))
+    sx1 = tensor(sigmax(), qeye(2), qeye(2))
+
+    sz2 = tensor(qeye(2), sigmaz(), qeye(2))
+    sx2 = tensor(qeye(2), sigmax(), qeye(2))
+
+    sz3 = tensor(qeye(2), qeye(2), sigmaz())
+    sx3 = tensor(qeye(2), qeye(2), sigmax())
+
+    idx = 0
+    evals_mat = np.zeros((len(w1list), 2 * 2 * 2))
+    for w1 in w1list:
+
+        # evaluate the Hamiltonian
+        H = w1 * sz1 + w2 * sz2 + w3 * sz3 + g12 * sx1 * sx2 + g13 * sx1 * sx3
+
+        # find the energy eigenvalues of the composite system
+        evals, ekets = H.eigenstates()
+
+        evals_mat[idx, :] = np.real(evals)
+
+        idx += 1
+
+    return evals_mat
+```
+
+```python
+w1 = 1.0 * 2 * pi  # atom 1 frequency: sweep this one
+w2 = 0.9 * 2 * pi  # atom 2 frequency
+w3 = 1.1 * 2 * pi  # atom 3 frequency
+g12 = 0.05 * 2 * pi  # atom1-atom2 coupling strength
+g13 = 0.05 * 2 * pi  # atom1-atom3 coupling strength
+
+w1list = np.linspace(0.75, 1.25, 50) * 2 * pi  # atom 1 frequency range
+```
+
+```python
+evals_mat = compute(w1list, w2, w3, g12, g13)
+```
+
+```python
+fig, ax = plt.subplots(figsize=(12, 6))
+
+for n in [1, 2, 3]:
+    ax.plot(w1list / (2 * pi),
+            (evals_mat[:, n] - evals_mat[:, 0]) / (2 * pi), "b")
+
+ax.set_xlabel("Energy splitting of atom 1")
+ax.set_ylabel("Eigenenergies")
+ax.set_title("Energy spectrum of three coupled qubits");
+```
+
+## Versions
+
+```python
+about()
+```

--- a/tutorials-v4/visualization/pseudo-probability-functions.md
+++ b/tutorials-v4/visualization/pseudo-probability-functions.md
@@ -1,0 +1,162 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# QuTiP example: Pseudo-probability functions
+
+
+J.R. Johansson and P.D. Nation
+
+For more information about QuTiP see [http://qutip.org](http://qutip.org)
+
+```python
+import matplotlib as mpl
+import matplotlib.pylab as plt
+import numpy as np
+from matplotlib import cm
+from mpl_toolkits.mplot3d import Axes3D
+from qutip import about, basis, dag, destroy, qfunc, wigner, wigner_cmap
+
+%matplotlib inline
+```
+
+## Wigner function for superposition of fock states
+
+```python
+x = 1.0 / np.sqrt(2) * (basis(10, 4) + basis(10, 2))
+xvec = np.arange(-5, 5, 10.0 / 100)
+yvec = xvec
+W = wigner(x, xvec, yvec)
+cmap = wigner_cmap(W)
+X, Y = np.meshgrid(xvec, yvec)
+```
+
+```python
+fig = plt.figure(figsize=(8, 6))
+plt.contourf(X, Y, W, 50, cmap=cmap)
+plt.colorbar();
+```
+
+```python
+fig = plt.figure(figsize=(10, 8))
+ax = Axes3D(fig, azim=-30, elev=73)
+ax.plot_surface(X, Y, W, cmap=cmap, rstride=1, cstride=1, alpha=1, linewidth=0)
+ax.set_zlim3d(-0.25, 0.25)
+for a in ax.w_zaxis.get_ticklines() + ax.w_zaxis.get_ticklabels():
+    a.set_visible(False)
+nrm = mpl.colors.Normalize(W.min(), W.max())
+cax, kw = mpl.colorbar.make_axes(ax, shrink=0.66, pad=0.02)
+cb1 = mpl.colorbar.ColorbarBase(cax, cmap=cmap, norm=nrm)
+cb1.set_label("Pseudoprobability")
+```
+
+## Winger and Q-function for squeezed states
+
+```python
+N = 20
+alpha = -1.0  # Coherent amplitude of field
+epsilon = 0.5j  # Squeezing parameter
+a = destroy(N)
+
+D = (alpha * a.dag() - np.conj(alpha) * a).expm()  # Displacement
+S = (
+    0.5 * np.conj(epsilon) * a * a - 0.5 * epsilon * a.dag() * a.dag()
+).expm()  # Squeezing
+psi = D * S * basis(N, 0)  # Apply to vacuum state
+g = 2
+```
+
+### Wigner function
+
+```python
+xvec = np.arange(-40.0, 40.0) * 5.0 / 40
+X, Y = np.meshgrid(xvec, xvec)
+
+W = wigner(psi, xvec, xvec)
+
+fig1 = plt.figure(figsize=(8, 6))
+ax = Axes3D(fig1)
+ax.plot_surface(X, Y, W, rstride=2, cstride=2, cmap=cm.jet, alpha=0.7)
+ax.contour(X, Y, W, 15, zdir="x", offset=-6)
+ax.contour(X, Y, W, 15, zdir="y", offset=6)
+ax.contour(X, Y, W, 15, zdir="z", offset=-0.3)
+ax.set_xlim3d(-6, 6)
+ax.set_xlim3d(-6, 6)
+ax.set_zlim3d(-0.3, 0.4)
+plt.title("Wigner function of squeezed state");
+```
+
+### Q-function
+
+```python
+Q = qfunc(psi, xvec, xvec, g)
+
+fig2 = plt.figure(figsize=(8, 6))
+ax = Axes3D(fig2)
+ax.plot_surface(X, Y, Q, rstride=2, cstride=2, cmap=cm.jet, alpha=0.7)
+ax.contour(X, Y, Q, zdir="x", offset=-6)
+ax.contour(X, Y, Q, zdir="y", offset=6)
+ax.contour(X, Y, Q, 15, zdir="z", offset=-0.4)
+ax.set_xlim3d(-6, 6)
+ax.set_xlim3d(-6, 6)
+ax.set_zlim3d(-0.3, 0.4)
+plt.title("Q function of squeezed state");
+```
+
+## Schrodinger cat state
+
+```python
+N = 20
+# amplitudes of coherent states
+alpha1 = -2.0 - 2j
+alpha2 = 2.0 + 2j
+# define ladder oeprators
+a = destroy(N)
+# define displacement oeprators
+D1 = (alpha1 * dag(a) - np.conj(alpha1) * a).expm()
+D2 = (alpha2 * dag(a) - np.conj(alpha2) * a).expm()
+# sum of coherent states
+psi = np.sqrt(2) ** -1 * (D1 + D2) * basis(N, 0);  # Apply to vacuum state
+```
+
+```python
+# calculate Wigner function
+yvec = xvec = np.arange(-100.0, 100.0) * 5.0 / 100
+g = 2.0
+W = wigner(psi, xvec, yvec)
+fig = plt.figure(figsize=(8, 6))
+c = plt.contourf(xvec, yvec, np.real(W), 100)
+plt.xlim([-5, 5])
+plt.ylim([-5, 5])
+plt.title("Wigner function of Schrodinger cat")
+cbar = plt.colorbar(c)
+cbar.ax.set_ylabel("Pseudoprobability");
+```
+
+```python
+# calculate Q function
+Q = qfunc(psi, xvec, yvec)
+fig = plt.figure(figsize=(8, 6))
+qplt = plt.contourf(xvec, yvec, np.real(Q), 100)
+plt.xlim([-5, 5])
+plt.ylim([-5, 5])
+plt.title("Q function of Schrodinger cat")
+cbar = plt.colorbar(qplt)
+cbar.ax.set_ylabel("Probability");
+```
+
+## Software version:
+
+```python
+about()
+```

--- a/tutorials-v4/visualization/quantum-process-tomography.md
+++ b/tutorials-v4/visualization/quantum-process-tomography.md
@@ -1,0 +1,115 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# QuTiP example: Quantum Process Tomography
+
+
+J.R. Johansson and P.D. Nation
+
+For more information about QuTiP see [http://qutip.org](http://qutip.org)
+
+```python
+import numpy as np
+from qutip import (about, qeye, qpt, qpt_plot_combined, sigmax, sigmay, sigmaz,
+                   spost, spre)
+from qutip_qip.operations import (cnot, fredkin, iswap, phasegate, snot,
+                                  sqrtiswap, swap, toffoli)
+
+%matplotlib inline
+```
+
+```python
+"""
+Plot the process tomography matrices for some 1, 2, and 3-qubit qubit gates.
+"""
+gates = [
+    ["C-NOT", cnot()],
+    ["SWAP", swap()],
+    ["$i$SWAP", iswap()],
+    [r"$\sqrt{i\mathrm{SWAP}}$", sqrtiswap()],
+    ["S-NOT", snot()],
+    [r"$\pi/2$ phase gate", phasegate(np.pi / 2)],
+    ["Toffoli", toffoli()],
+    ["Fredkin", fredkin()],
+]
+```
+
+```python
+def plt_qpt_gate(gate, figsize=(8, 6)):
+
+    name = gate[0]
+    U_psi = gate[1]
+
+    N = len(U_psi.dims[0])  # number of qubits
+
+    # create a superoperator for the density matrix
+    # transformation rho = U_psi * rho_0 * U_psi.dag()
+    U_rho = spre(U_psi) * spost(U_psi.dag())
+
+    # operator basis for the process tomography
+    op_basis = [[qeye(2), sigmax(), sigmay(), sigmaz()] for i in range(N)]
+
+    # labels for operator basis
+    op_label = [["$i$", "$x$", "$y$", "$z$"] for i in range(N)]
+
+    # calculate the chi matrix
+    chi = qpt(U_rho, op_basis)
+
+    # visualize the chi matrix
+    fig, ax = qpt_plot_combined(chi, op_label, name, figsize=figsize)
+
+    ax.set_title(name)
+
+    return fig, ax
+```
+
+```python
+plt_qpt_gate(gates[0]);
+```
+
+```python
+plt_qpt_gate(gates[1]);
+```
+
+```python
+plt_qpt_gate(gates[2]);
+```
+
+```python
+plt_qpt_gate(gates[3]);
+```
+
+```python
+plt_qpt_gate(gates[4]);
+```
+
+```python
+plt_qpt_gate(gates[5]);
+```
+
+```python
+fig, ax = plt_qpt_gate(gates[6], figsize=(16, 12))
+ax.axis("tight");
+```
+
+```python
+fig, ax = plt_qpt_gate(gates[7], figsize=(16, 12))
+ax.axis("tight");
+```
+
+## Versions
+
+```python
+about()
+```

--- a/tutorials-v4/visualization/qubism-and-schmidt-plots.md
+++ b/tutorials-v4/visualization/qubism-and-schmidt-plots.md
@@ -1,0 +1,442 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# QuTiP example: Qubism visualizations
+
+
+by [Piotr Migdał](http://migdal.wikidot.com/), June 2014
+
+For more information about QuTiP see http://qutip.org.
+
+For more information about Qubism see:
+* J. Rodriguez-Laguna, P. Migdał, M. Ibanez Berganza, M. Lewenstein, G. Sierra,
+  [Qubism: self-similar visualization of many-body wavefunctions](http://dx.doi.org/10.1088/1367-2630/14/5/053028), New J. Phys. 14 053028 (2012), [arXiv:1112.3560](http://arxiv.org/abs/1112.3560),
+* [its video abstract](https://www.youtube.com/watch?v=8fPAzOziTZo),
+* [C++ and Mathematica code on GitHub](https://github.com/stared/qubism).
+
+This note describes plotting functions `plot_schmidt` and `plot_qubism`, and additionally - `complex_array_to_rgb`, along with their applications.
+
+
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from qutip import (Qobj, about, complex_array_to_rgb, jmat, ket, plot_qubism,
+                   plot_schmidt, qeye, sigmax, sigmay, sigmaz, tensor)
+
+%matplotlib inline
+```
+
+## Colors
+
+
+In quantum mechanics, complex numbers are as natual as real numbers.
+
+Before going into details of particular plots, we show how `complex_array_to_rgb` maps $z = x + i y$ into colors.
+There are two variants, `theme='light'` and `theme='dark'`. For both, we use hue for phase, with red for positive numbers and aqua for negative.
+
+For a longer comment on coloring complex functions I recommend IPython Notebook [Visualizing complex-valued functions with Matplotlib and Mayavi](http://nbviewer.ipython.org/github/empet/Math/blob/master/DomainColoring.ipynb) by Emilia Petrisor.
+
+```python
+compl_circ = np.array(
+    [
+        [(x + 1j * y) if x ** 2 + y**2 <= 1 else 0j
+            for x in np.arange(-1, 1, 0.005)]
+        for y in np.arange(-1, 1, 0.005)
+    ]
+)
+
+fig = plt.figure(figsize=(6, 3))
+for i, theme in enumerate(["light", "dark"]):
+    ax = plt.subplot(1, 2, i + 1)
+    ax.set_xlabel("x", fontsize=14)
+    ax.set_ylabel("y", fontsize=14)
+    ax.imshow(
+        complex_array_to_rgb(compl_circ, rmax=1, theme=theme),
+        extent=(-1, 1, -1, 1)
+    )
+plt.tight_layout()
+```
+
+## Schmidt plot
+
+
+Arguably, the easiest way to show entanglement is to plot a wavefunction against two variables.
+If the plot is a product of them, the state is a product state. If not - it is entangled.
+
+As writing a wavefunction as a matrix $|\psi\rangle_{ij}$ is the the crucial step in [Schmidt decomposition](http://en.wikipedia.org/wiki/Schmidt_decomposition),
+we call such plots Schmidt plots.
+
+Let us consider two states:
+
+* entangled: singlet state $|\psi^-\rangle = (|01\rangle - |10\rangle)/\sqrt{2}$,
+* product $(|01\rangle - |00\rangle)/\sqrt{2}$.
+
+They may look seamingly similar, but the later can be decomposed into a product $|0\rangle(|1\rangle - |0\rangle)/\sqrt{2}$.
+
+```python
+singlet = (ket("01") - ket("10")).unit()
+separable = (ket("01") - ket("00")).unit()
+```
+
+```python
+plot_schmidt(singlet, figsize=(2, 2));
+```
+
+```python
+plot_schmidt(separable, figsize=(2, 2));
+```
+
+As we see, for separable state the plot is a product of `x` and `y` coordinates, while for the singlet state - is is not.
+
+Let us now consider a product of two singlet states: $|\psi^-\rangle|\psi^-\rangle$.
+Schmidt plot, by default, makes spliting of equal numbers of particles.
+
+(And just for fun, let's multiply it by the imaginary unit, to get diffeerent colors.)
+
+```python
+plot_schmidt(1j * tensor([singlet, singlet]), figsize=(2, 2));
+```
+
+As we see, we have a product, as the state is a product state with the respect to the splitting of first 2 vs last 2 particles.
+
+But what if we shift particles, getting $|\psi^-\rangle_{23}|\psi^-\rangle_{41}$?
+
+```python
+plot_schmidt(1j * tensor([singlet, singlet]).permute([1, 2, 3, 0]),
+             figsize=(2, 2));
+```
+
+So we see that it is entangled.
+
+`plot_schmidt` allows us to specify other splittings. With parameter `splitting` we decide how many particles we want to have as columns. In general, we can plot systems of various numbers of particles, each being of a different dimension.
+
+For example:
+
+```python
+plot_schmidt(
+    1j * tensor([singlet, singlet]),
+    splitting=1,
+    labels_iteration=(1, 3),
+    figsize=(4, 2),
+);
+```
+
+## Qubism plot
+
+```python
+fig = plt.figure(figsize=(8, 4))
+for i in [1, 2]:
+    ax = plt.subplot(1, 2, i)
+    plot_qubism(0 * ket("0000"), legend_iteration=i, grid_iteration=i,
+                fig=fig, ax=ax)
+```
+
+That is, all amplitudes for states starting with:
+
+* $|00\rangle$ go to the upper left quadrant,
+* $|01\rangle$ go to the upper right quadrant,
+* $|10\rangle$ go to the lower left quadrant,
+* $|11\rangle$ go to the lower right quadrant.
+
+And we proceed recursively with the next particles. So, for example:
+
+```python
+state = (
+    ket("0010")
+    + 0.5 * ket("1111")
+    + 0.5j * ket("0101")
+    - 1j * ket("1101")
+    - 0.2 * ket("0110")
+)
+plot_qubism(state, figsize=(4, 4));
+```
+
+Or if we want to make sure how did we map amplitudes to particular regions in the plot:
+
+```python
+plot_qubism(state, legend_iteration=2, figsize=(4, 4));
+```
+
+Or how about making it dark? (E.g. to fit out slides with black background).
+
+```python
+plot_qubism(state, legend_iteration=2, theme="dark", figsize=(4, 4));
+```
+
+The most important property of Qubism is the recursive structure. So that we can add more particles seamlessly.
+For example, let's consider a plot of `k` copies of the singlet states, i.e. $|\psi^-\rangle^{\otimes k}$:
+
+```python
+fig = plt.figure(figsize=(15, 3))
+for k in range(1, 6):
+    ax = plt.subplot(1, 5, k)
+    plot_qubism(tensor([singlet] * k), fig=fig, ax=ax)
+```
+
+OK, but once we can type the wavefunction by hand, plots offer little added value.
+
+Let's see how we can plot ground states.
+Before doing that, we define some functions to easy make a translationally-invariant Hamiltonian.
+
+```python
+def spinchainize(op, n, bc="periodic"):
+
+    if isinstance(op, list):
+        return sum([spinchainize(each, n, bc=bc) for each in op])
+
+    k = len(op.dims[0])
+    d = op.dims[0][0]
+
+    expanded = tensor([op] + [qeye(d)] * (n - k))
+
+    if bc == "periodic":
+        shifts = n
+    elif bc == "open":
+        shifts = n - k + 1
+
+    shifteds = [
+        expanded.permute([(i + j) % n for i in range(n)])
+        for j in range(shifts)
+    ]
+
+    return sum(shifteds)
+
+
+def gs_of(ham):
+    gval, gstate = ham.groundstate()
+    return gstate
+```
+
+For example, let us consider Hamiltonian for $N$ particles, of the following form (a generalization of the [Majumdar-Ghosh model](http://en.wikipedia.org/wiki/Majumdar%E2%80%93Ghosh_Model)):
+
+$$H = \sum_{i=1}^N \vec{S}_i \cdot \vec{S}_{i+1} + J \sum_{i=1}^N \vec{S}_i \cdot \vec{S}_{i+2},$$
+
+where $\vec{S}_i = \tfrac{1}{2} (\sigma^x, \sigma^y, \sigma^z)$ is the spin operator (with sigmas being [Pauli matrices](http://en.wikipedia.org/wiki/Pauli_matrices)).
+
+Moreover, we can set two different boundary conditions:
+
+* periodic - spin chain forms a loop ($N+1 \equiv 1$ and $N+2 \equiv 2$),
+* open - spin chain forms a line (we remove terms with $N+1$ and $N+2$).
+
+```python
+heis = sum([tensor([pauli] * 2) for pauli in [sigmax(), sigmay(), sigmaz()]])
+heis2 = sum(
+    [tensor([pauli, qeye(2), pauli])
+     for pauli in [sigmax(), sigmay(), sigmaz()]]
+)
+
+N = 10
+Js = [0.0, 0.5, 1.0]
+
+fig = plt.figure(figsize=(2 * len(Js), 4.4))
+
+for b in [0, 1]:
+    for k, J in enumerate(Js):
+        ax = plt.subplot(2, len(Js), b * len(Js) + k + 1)
+
+        if b == 0:
+            spinchain = spinchainize([heis, J * heis2], N, bc="periodic")
+        elif b == 1:
+            spinchain = spinchainize([heis, J * heis2], N, bc="open")
+
+        plot_qubism(gs_of(spinchain), ax=ax)
+
+        if k == 0:
+            if b == 0:
+                ax.set_ylabel("periodic BC", fontsize=16)
+            else:
+                ax.set_ylabel("open BC", fontsize=16)
+        if b == 1:
+            ax.set_xlabel("$J={0:.1f}$".format(J), fontsize=16)
+
+plt.tight_layout()
+```
+
+We are not restricted to qubits. We can have it for other dimensions, e.g. qutrits.
+
+Let us consider [AKLT model](http://en.wikipedia.org/wiki/AKLT_Model) for spin-1 particles:
+
+$$H = \sum_{i=1}^N \vec{S}_i \cdot \vec{S}_{i+1} + \tfrac{1}{3} \sum_{i=1}^N (\vec{S}_i \cdot \vec{S}_{i+1})^2.$$
+
+where $\vec{S}_i$ is [spin operator](http://en.wikipedia.org/wiki/Pauli_matrices#Physics) for spin-1 particles (or for `qutip`: `jmat(1, 'x')`, `jmat(1, 'y')` and `jmat(1, 'z')`).
+
+```python
+ss = sum([tensor([jmat(1, s)] * 2) for s in ["x", "y", "z"]])
+H = spinchainize([ss, (1.0 / 3.0) * ss**2], n=6, bc="periodic")
+plot_qubism(gs_of(H), figsize=(4, 4));
+```
+
+Qubism for qutrits works similarly as for qubits:
+
+```python
+fig = plt.figure(figsize=(10, 5))
+for i in [1, 2]:
+    ax = plt.subplot(1, 2, i)
+    plot_qubism(
+        0 * ket("0000", dim=3), legend_iteration=i, grid_iteration=i,
+        fig=fig, ax=ax
+    )
+```
+
+Just in this case we interpret:
+
+* 0 as $s_z=-1$,
+* 1 as $s_z=\ \ 0$,
+* 2 as $s_z=+1$.
+
+While qubism works best for translationally-invariants states (so in particular, all particles need to have the same dimension), we can do it for others.
+
+Also, there are a few other Qubism-related plotting schemes. For example `how='pairs_skewed'`:
+
+```python
+fig = plt.figure(figsize=(8, 4))
+for i in [1, 2]:
+    ax = plt.subplot(1, 2, i)
+    plot_qubism(
+        0 * ket("0000"),
+        how="pairs_skewed",
+        legend_iteration=i,
+        grid_iteration=i,
+        fig=fig,
+        ax=ax,
+    )
+```
+
+The one above emphasis ferromagnetic (put on the left) vs antiferromagnetic (put on the right) states.
+
+Another one `how='before_after'` (inspired by [this](http://commons.wikimedia.org/wiki/File:Ising-tartan.png)) works in a bit different way: it uses typical recursion, but starting from middle particles. For example, the top left quadrant correspons to $|00\rangle_{N/2,N/2+1}$: 
+
+```python
+fig = plt.figure(figsize=(8, 4))
+for i in [1, 2]:
+    ax = plt.subplot(1, 2, i)
+    plot_qubism(
+        0 * ket("0000"),
+        how="before_after",
+        legend_iteration=i,
+        grid_iteration=i,
+        fig=fig,
+        ax=ax,
+    )
+```
+
+It is very similar to the Schmidt plot (for the default splitting), with the only difference being ordering of the `y` axis (particle order is reversed). All entanglement properties are the same.
+
+So how does it work on the same example? 
+Well, let us take spin chain for (Majumdar-Ghosh model for $J=0$), i.e.
+$$H = \sum_{i=1}^N \vec{S}_i \cdot \vec{S}_{i+1}$$
+for qubits.
+
+```python
+heis = sum([tensor([pauli] * 2) for pauli in [sigmax(), sigmay(), sigmaz()]])
+N = 10
+gs = gs_of(spinchainize(heis, N, bc="periodic"))
+
+fig = plt.figure(figsize=(12, 4))
+for i, how in enumerate(["schmidt_plot", "pairs",
+                         "pairs_skewed", "before_after"]):
+    ax = plt.subplot(1, 4, i + 1)
+    if how == "schmidt_plot":
+        plot_schmidt(gs, fig=fig, ax=ax)
+    else:
+        plot_qubism(gs, how=how, fig=fig, ax=ax)
+    ax.set_title(how)
+plt.tight_layout()
+```
+
+## Seeing entanglement
+
+```python
+product_1 = ket("0000")
+product_2 = tensor([(ket("0") + ket("1")).unit()] * 4)
+w = (ket("0001") + ket("0010") + ket("0100") + ket("1000")).unit()
+dicke_2of4 = (
+    ket("0011") + ket("0101") + ket("0110") +
+    ket("1001") + ket("1010") + ket("1100")
+).unit()
+ghz = (ket("0000") + ket("1111")).unit()
+```
+
+```python
+states = ["product_1", "product_2", "w", "dicke_2of4", "ghz"]
+fig = plt.figure(figsize=(2 * len(states), 2))
+for i, state_str in enumerate(states):
+    ax = plt.subplot(1, len(states), i + 1)
+    plot_qubism(eval(state_str), fig=fig, ax=ax)
+    ax.set_title(state_str)
+plt.tight_layout()
+```
+
+Then entanglement (or exactly: Schmidt rank) for a given partition is equal to number to different, non-zero squares. (We don't allow rotations, we do allow multiplication by a factor and, what may be more tricky, linear superposition.)
+
+Here we use partition of first 2 particles vs last 2, as indicated by lines.
+
+That is,
+* `product_1` - only 1 non-zero square: Schmidt rank 1,
+* `product_2` - 4 non-zero squares, but they are the same: Schmidt rank 1,
+* `w` - 3 non-zero quares, but two of them are the same: Schmidt rank 2,
+* `dicke_2of4` - 4 non-zero squares, but two of them are the same: Schmidt rank 3,
+* `ghz` - 2 non-zero squares, each one different: Schmidt rank 2.
+
+This is basis-independent, but it may be easier to work in one basis rather than another.
+
+And for a comparision, let us see product states:
+
+$$\left( \cos(\theta/2) |0\rangle + \sin(\theta/2) e^{i \varphi} |1\rangle \right)^N $$
+
+```python
+def product_state(theta, phi=0, n=1):
+    single = Qobj([[np.cos(theta / 2.0)],
+                   [np.sin(theta / 2.0) * np.exp(1j * phi)]])
+    return tensor([single] * n)
+
+
+thetas = 0.5 * np.pi * np.array([0.0, 0.5, 0.75, 1.0])
+phis = np.pi * np.array([0.0, 0.1, 0.2, 0.3])
+
+fig, axes2d = plt.subplots(nrows=len(phis),
+                           ncols=len(thetas), figsize=(6, 6))
+
+for i, row in enumerate(axes2d):
+    for j, cell in enumerate(row):
+        plot_qubism(
+            product_state(thetas[j], phi=phis[i], n=8),
+            grid_iteration=1, ax=cell
+        )
+        if i == len(axes2d) - 1:
+            cell.set_xlabel(
+                r"$\theta={0:s}\pi$".format(
+                    ["0", "(1/4)", "(3/8)", "(1/2)"][j]),
+                fontsize=16,
+            )
+        if j == 0:
+            cell.set_ylabel(
+                r"$\varphi={0:.1f}\pi$".format(phis[i] / np.pi), fontsize=16
+            )
+
+plt.tight_layout()
+```
+
+In each plot squares are the same, up to a factor (which is visualized as intensity and hue).
+
+You can lookup previous plots. Setting `grid_iteration=2` would show splitting of the first 4 particles vs N-4 others.
+And for `how='before_after'` it is the middle particles vs all others.
+
+
+### Versions
+
+```python
+about()
+```

--- a/tutorials-v4/visualization/visualization-exposition.md
+++ b/tutorials-v4/visualization/visualization-exposition.md
@@ -1,0 +1,189 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# Development notebook for testing the visualization module in QuTiP
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import qutip as qt
+from qutip import about, basis, identity, sigmax, sigmay, sigmaz
+
+%matplotlib inline
+```
+
+## Hinton
+
+```python
+rho = qt.rand_dm(5)
+```
+
+```python
+qt.hinton(rho);
+```
+
+## Sphereplot
+
+```python
+theta = np.linspace(0, np.pi, 90)
+phi = np.linspace(0, 2 * np.pi, 60)
+```
+
+```python
+qt.sphereplot(theta, phi, qt.orbital(theta, phi, basis(3, 0)).T);
+```
+
+```python
+fig = plt.figure(figsize=(16, 4))
+
+ax = fig.add_subplot(1, 3, 1, projection="3d")
+qt.sphereplot(theta, phi, qt.orbital(theta, phi, basis(3, 0)).T, fig, ax)
+
+ax = fig.add_subplot(1, 3, 2, projection="3d")
+qt.sphereplot(theta, phi, qt.orbital(theta, phi, basis(3, 1)).T, fig, ax)
+
+ax = fig.add_subplot(1, 3, 3, projection="3d")
+qt.sphereplot(theta, phi, qt.orbital(theta, phi, basis(3, 2)).T, fig, ax);
+```
+
+# Matrix histogram
+
+```python
+qt.matrix_histogram(rho.full().real);
+```
+
+```python
+qt.matrix_histogram_complex(rho.full());
+```
+
+# Plot energy levels
+
+```python
+H0 = qt.tensor(sigmaz(), identity(2)) + qt.tensor(identity(2), sigmaz())
+Hint = 0.1 * qt.tensor(sigmax(), sigmax())
+
+qt.plot_energy_levels([H0, Hint], figsize=(8, 4));
+```
+
+# Plot Fock distribution
+
+```python
+rho = (qt.coherent(15, 1.5) + qt.coherent(15, -1.5)).unit()
+```
+
+```python
+qt.plot_fock_distribution(rho);
+```
+
+# Plot Wigner function and Fock distribution
+
+```python
+qt.plot_wigner_fock_distribution(rho);
+```
+
+# Plot winger function
+
+```python
+qt.plot_wigner(rho, figsize=(6, 6));
+```
+
+# Plot expectation values
+
+```python
+H = sigmaz() + 0.3 * sigmay()
+e_ops = [sigmax(), sigmay(), sigmaz()]
+times = np.linspace(0, 10, 100)
+psi0 = (basis(2, 0) + basis(2, 1)).unit()
+result = qt.mesolve(H, psi0, times, [], e_ops)
+```
+
+```python
+qt.plot_expectation_values(result);
+```
+
+# Bloch sphere
+
+```python
+b = qt.Bloch()
+b.add_vectors(qt.expect(H.unit(), e_ops))
+b.add_points(result.expect, meth="l")
+b.make_sphere()
+```
+
+# Plot spin Q-functions
+
+```python
+j = 5
+psi = qt.spin_state(j, -j)
+psi = qt.spin_coherent(j, np.random.rand() * np.pi,
+                       np.random.rand() * 2 * np.pi)
+rho = qt.ket2dm(psi)
+```
+
+```python
+theta = np.linspace(0, np.pi, 50)
+phi = np.linspace(0, 2 * np.pi, 50)
+```
+
+```python
+Q, THETA, PHI = qt.spin_q_function(psi, theta, phi)
+```
+
+## 2D
+
+```python
+qt.plot_spin_distribution_2d(Q, THETA, PHI);
+```
+
+## 3D
+
+```python
+fig, ax = qt.plot_spin_distribution_3d(Q, THETA, PHI)
+
+ax.view_init(15, 30)
+```
+
+## Combined 2D and 3D
+
+```python
+fig = plt.figure(figsize=(14, 6))
+
+ax = fig.add_subplot(1, 2, 1)
+f1, a1 = qt.plot_spin_distribution_2d(Q, THETA, PHI, fig=fig, ax=ax)
+
+ax = fig.add_subplot(1, 2, 2, projection="3d")
+f2, a2 = qt.plot_spin_distribution_3d(Q, THETA, PHI, fig=fig, ax=ax)
+```
+
+# Plot spin-Wigner functions
+
+```python
+W, THETA, PHI = qt.spin_wigner(psi, theta, phi)
+```
+
+```python
+fig = plt.figure(figsize=(14, 6))
+
+ax = fig.add_subplot(1, 2, 1)
+f1, a1 = qt.plot_spin_distribution_2d(W.real, THETA, PHI, fig=fig, ax=ax)
+
+ax = fig.add_subplot(1, 2, 2, projection="3d")
+f2, a2 = qt.plot_spin_distribution_3d(W.real, THETA, PHI, fig=fig, ax=ax)
+```
+
+# Versions
+
+```python
+about()
+```

--- a/tutorials-v5/visualization/JC-model-wigner-function.md
+++ b/tutorials-v5/visualization/JC-model-wigner-function.md
@@ -25,7 +25,6 @@ For more information about QuTiP see [http://qutip.org](http://qutip.org)
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import cm
-from mpl_toolkits.mplot3d import Axes3D
 from qutip import about, basis, destroy, mesolve, ptrace, qeye, tensor, wigner
 from qutip.ipynbtools import plot_animation
 

--- a/tutorials-v5/visualization/JC-model-wigner-function.md
+++ b/tutorials-v5/visualization/JC-model-wigner-function.md
@@ -1,0 +1,163 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernel_info:
+    name: python3
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+ QuTiP example: Wigner function animation for the dynamics of the Jaynes-Cumming model
+
+
+J.R. Johansson and P.D. Nation
+
+For more information about QuTiP see [http://qutip.org](http://qutip.org)
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import cm
+from mpl_toolkits.mplot3d import Axes3D
+from qutip import about, basis, destroy, mesolve, ptrace, qeye, tensor, wigner
+from qutip.ipynbtools import plot_animation
+
+%matplotlib inline
+```
+
+```python
+def jc_integrate(N, wc, wa, g, kappa, gamma, psi0, use_rwa, tlist):
+
+    # Hamiltonian
+    idc = qeye(N)
+    ida = qeye(2)
+
+    a = tensor(destroy(N), ida)
+    sm = tensor(idc, destroy(2))
+
+    if use_rwa:
+        # use the rotating wave approxiation
+        H = wc * a.dag() * a + wa * sm.dag() * sm + \
+            g * (a.dag() * sm + a * sm.dag())
+    else:
+        H = wc * a.dag() * a + wa * sm.dag() * sm + \
+            g * (a.dag() + a) * (sm + sm.dag())
+
+    # collapse operators
+    c_op_list = []
+
+    n_th_a = 0.0  # zero temperature
+
+    rate = kappa * (1 + n_th_a)
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * a)
+
+    rate = kappa * n_th_a
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * a.dag())
+
+    rate = gamma
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * sm)
+
+    # evolve and calculate return state vectors
+    result = mesolve(H, psi0, tlist, c_op_list, [])
+
+    return result
+```
+
+```python
+# parameters
+wc = 1.0 * 2 * np.pi  # cavity frequency
+wa = 1.0 * 2 * np.pi  # atom frequency
+g = 0.05 * 2 * np.pi  # coupling strength
+kappa = 0.05  # cavity dissipation rate
+gamma = 0.15  # atom dissipation rate
+N = 10  # number of cavity fock states
+
+use_rwa = True
+
+# start with an excited atom
+psi0 = tensor(basis(N, 0), basis(2, 1))
+# or a coherent state the in cavity
+# psi0 = tensor(coherent(N,1.5), basis(2,0))
+# or a superposition of coherent states
+# psi0 = tensor((coherent(N,2.0)+coherent(N,-2.0)).unit(), basis(2,0))
+
+tlist = np.linspace(0, 30, 150)
+```
+
+```python
+result = jc_integrate(N, wc, wa, g, kappa, gamma, psi0, use_rwa, tlist)
+```
+
+```python
+xvec = np.linspace(-5.0, 5.0, 100)
+X, Y = np.meshgrid(xvec, xvec)
+```
+
+```python
+def plot_setup(result):
+
+    fig = plt.figure(figsize=(12, 6))
+    ax = fig.add_subplot(111, projection="3d", elev=49, azim=-107)
+
+    return fig, ax
+```
+
+```python
+cb = None
+
+
+def plot_result(result, n, fig=None, axes=None):
+
+    global cb
+
+    if fig is None or axes is None:
+        fig, ax = plot_setup(result)
+
+    axes.cla()
+
+    # trace out the atom
+    rho_cavity = ptrace(result.states[n], 0)
+
+    W = wigner(rho_cavity, xvec, xvec)
+
+    surf = axes.plot_surface(
+        X,
+        Y,
+        W,
+        rstride=1,
+        cstride=1,
+        cmap=cm.jet,
+        alpha=1.0,
+        linewidth=0.05,
+        vmax=0.25,
+        vmin=-0.25,
+    )
+    axes.set_xlim3d(-5, 5)
+    axes.set_ylim3d(-5, 5)
+    axes.set_zlim3d(-0.25, 0.25)
+
+    if not cb:
+        cb = plt.colorbar(surf, shrink=0.65, aspect=20)
+
+    return axes.artists
+```
+
+```python
+plot_animation(plot_setup, plot_result, result, writer="ffmpeg", codec=None)
+```
+
+# Versions
+
+```python
+about()
+```

--- a/tutorials-v5/visualization/bloch-sphere-animation.md
+++ b/tutorials-v5/visualization/bloch-sphere-animation.md
@@ -1,0 +1,130 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# QuTiP example: Bloch sphere animation
+
+
+J.R. Johansson and P.D. Nation
+
+For more information about QuTiP see [http://qutip.org](http://qutip.org)
+
+
+Animation with qutip and matplotlib: decaying qubit visualized in a Bloch sphere.
+(Animation with matplotlib does not work yet in python3)
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from mpl_toolkits.mplot3d import Axes3D
+from qutip import Bloch, about, basis, mesolve, sigmam, sigmax, sigmay, sigmaz
+from qutip.ipynbtools import plot_animation
+
+%matplotlib inline
+```
+
+```python
+def qubit_integrate(w, theta, gamma1, gamma2, psi0, tlist):
+    # operators and the hamiltonian
+    sx = sigmax()
+    sy = sigmay()
+    sz = sigmaz()
+    sm = sigmam()
+    H = w * (np.cos(theta) * sz + np.sin(theta) * sx)
+    # collapse operators
+    c_op_list = []
+    n_th = 0.5  # temperature
+    rate = gamma1 * (n_th + 1)
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * sm)
+    rate = gamma1 * n_th
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * sm.dag())
+    rate = gamma2
+    if rate > 0.0:
+        c_op_list.append(np.sqrt(rate) * sz)
+
+    # evolve and calculate expectation values
+    output = mesolve(H, psi0, tlist, c_op_list, [sx, sy, sz])
+    return output
+```
+
+```python
+w = 1.0 * 2 * np.pi  # qubit angular frequency
+theta = 0.2 * np.pi  # qubit angle from sigma_z axis (toward sigma_x axis)
+gamma1 = 0.5  # qubit relaxation rate
+gamma2 = 0.2  # qubit dephasing rate
+# initial state
+a = 1.0
+psi0 = (a * basis(2, 0) + (1 - a) * basis(2, 1)) / \
+        (np.sqrt(a**2 + (1 - a) ** 2))
+tlist = np.linspace(0, 4, 150)
+```
+
+```python
+result = qubit_integrate(w, theta, gamma1, gamma2, psi0, tlist)
+```
+
+```python
+def plot_setup(result):
+
+    fig = plt.figure(figsize=(8, 8))
+    axes = fig.add_subplot(111, projection="3d", elev=30, azim=-40)
+
+    return fig, axes
+```
+
+```python
+sphere = None
+
+
+def plot_result(result, n, fig=None, axes=None):
+
+    global sphere
+
+    if fig is None or axes is None:
+        fig, axes = plot_setup(result)
+
+    if not sphere:
+        sphere = Bloch(axes=axes)
+        sphere.vector_color = ["r"]
+
+    sphere.clear()
+    sphere.add_vectors([result.expect[0][n],
+                        result.expect[1][n],
+                        result.expect[2][n]])
+    sphere.add_points(
+        [
+            result.expect[0][: n + 1],
+            result.expect[1][: n + 1],
+            result.expect[2][: n + 1],
+        ],
+        meth="l",
+    )
+    sphere.make_sphere()
+
+    return axes.artists
+```
+
+```python
+# You can choose your own writer and codec here.
+# Setting codec=None sets the codec to the standard
+# defined in matplotlib.rcParams['animation.codec']
+plot_animation(plot_setup, plot_result, result, writer="ffmpeg", codec=None)
+```
+
+## Versions
+
+```python
+about()
+```

--- a/tutorials-v5/visualization/bloch-sphere-animation.md
+++ b/tutorials-v5/visualization/bloch-sphere-animation.md
@@ -26,7 +26,6 @@ Animation with qutip and matplotlib: decaying qubit visualized in a Bloch sphere
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from mpl_toolkits.mplot3d import Axes3D
 from qutip import Bloch, about, basis, mesolve, sigmam, sigmax, sigmay, sigmaz
 from qutip.ipynbtools import plot_animation
 

--- a/tutorials-v5/visualization/bloch_sphere_with_colorbar.md
+++ b/tutorials-v5/visualization/bloch_sphere_with_colorbar.md
@@ -1,0 +1,92 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# Adding a colorbar to a Bloch Sphere
+
+```python
+import matplotlib as mpl
+import numpy as np
+from matplotlib import cm
+from qutip import Bloch, about, basis, destroy, sesolve, sigmax, sigmay, sigmaz
+
+%matplotlib inline
+```
+
+## Do a closed Landau-Zener Evolution
+
+```python
+delta = 0.5 * 2 * np.pi
+v = 2.0 * 2 * np.pi  # sweep rate
+
+H0 = delta / 2.0 * sigmax()
+H1 = v / 2.0 * sigmaz()
+H = [H0, [H1, "t"]]
+psi0 = basis(2, 0)
+
+sm = destroy(2)
+sx = sigmax()
+sy = sigmay()
+sz = sigmaz()
+expt_ops = [sm.dag() * sm, sx, sy, sz]
+
+
+tlist = np.linspace(-10.0, 10.0, 1500)
+expt_list = sesolve(H, psi0, tlist, expt_ops).expect
+```
+
+## Generate a Bloch Sphere with Multi-Colored Points
+
+
+Note that I need to call `b.show` here so that I can grab a Figure instance later
+
+```python
+b = Bloch()
+# normalize colors to times in tlist ##
+nrm = mpl.colors.Normalize(-2, 10)
+colors = cm.cool(nrm(tlist))
+
+# add data points from expectation values ##
+b.add_points([expt_list[1], expt_list[2], -expt_list[3]], "m")
+
+# customize sphere properties ##
+b.point_color = list(colors)
+b.point_marker = ["o"]
+b.point_size = [20]
+
+b.zlpos = [1.1, -1.2]
+
+b.show()
+```
+
+## Add  New Axis to Bloch Figure
+
+```python
+left, bottom, width, height = [0.98, 0.05, 0.05, 0.9]
+ax2 = b.fig.add_axes([left, bottom, width, height])
+
+mpl.colorbar.ColorbarBase(ax2, cmap=cm.cool, norm=nrm, orientation="vertical");
+```
+
+## Plot with Colorbar Added
+
+
+Currently I need to call `b.fig` as replotting figures in a notebook is a bit tricky.  However, this is likely to be improved in the future.
+
+```python
+b.fig
+```
+
+```python
+about()
+```

--- a/tutorials-v5/visualization/energy-levels.md
+++ b/tutorials-v5/visualization/energy-levels.md
@@ -1,0 +1,93 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# QuTiP example: Energy-levels of a quantum systems as a function of a single parameter
+
+
+J.R. Johansson and P.D. Nation
+
+For more information about QuTiP see [http://qutip.org](http://qutip.org)
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from numpy import pi
+from qutip import about, qeye, sigmax, sigmaz, tensor
+
+%matplotlib inline
+```
+
+## Energy spectrum of three coupled qubits
+
+```python
+def compute(w1list, w2, w3, g12, g13):
+
+    # Pre-compute operators for the hamiltonian
+    sz1 = tensor(sigmaz(), qeye(2), qeye(2))
+    sx1 = tensor(sigmax(), qeye(2), qeye(2))
+
+    sz2 = tensor(qeye(2), sigmaz(), qeye(2))
+    sx2 = tensor(qeye(2), sigmax(), qeye(2))
+
+    sz3 = tensor(qeye(2), qeye(2), sigmaz())
+    sx3 = tensor(qeye(2), qeye(2), sigmax())
+
+    idx = 0
+    evals_mat = np.zeros((len(w1list), 2 * 2 * 2))
+    for w1 in w1list:
+
+        # evaluate the Hamiltonian
+        H = w1 * sz1 + w2 * sz2 + w3 * sz3 + g12 * sx1 * sx2 + g13 * sx1 * sx3
+
+        # find the energy eigenvalues of the composite system
+        evals, ekets = H.eigenstates()
+
+        evals_mat[idx, :] = np.real(evals)
+
+        idx += 1
+
+    return evals_mat
+```
+
+```python
+w1 = 1.0 * 2 * pi  # atom 1 frequency: sweep this one
+w2 = 0.9 * 2 * pi  # atom 2 frequency
+w3 = 1.1 * 2 * pi  # atom 3 frequency
+g12 = 0.05 * 2 * pi  # atom1-atom2 coupling strength
+g13 = 0.05 * 2 * pi  # atom1-atom3 coupling strength
+
+w1list = np.linspace(0.75, 1.25, 50) * 2 * pi  # atom 1 frequency range
+```
+
+```python
+evals_mat = compute(w1list, w2, w3, g12, g13)
+```
+
+```python
+fig, ax = plt.subplots(figsize=(12, 6))
+
+for n in [1, 2, 3]:
+    ax.plot(w1list / (2 * pi),
+            (evals_mat[:, n] - evals_mat[:, 0]) / (2 * pi), "b")
+
+ax.set_xlabel("Energy splitting of atom 1")
+ax.set_ylabel("Eigenenergies")
+ax.set_title("Energy spectrum of three coupled qubits");
+```
+
+## Versions
+
+```python
+about()
+```

--- a/tutorials-v5/visualization/pseudo-probability-functions.md
+++ b/tutorials-v5/visualization/pseudo-probability-functions.md
@@ -1,0 +1,162 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# QuTiP example: Pseudo-probability functions
+
+
+J.R. Johansson and P.D. Nation
+
+For more information about QuTiP see [http://qutip.org](http://qutip.org)
+
+```python
+import matplotlib as mpl
+import matplotlib.pylab as plt
+import numpy as np
+from matplotlib import cm
+from mpl_toolkits.mplot3d import Axes3D
+from qutip import about, basis, destroy, qfunc, wigner, wigner_cmap
+
+%matplotlib inline
+```
+
+## Wigner function for superposition of fock states
+
+```python
+x = 1.0 / np.sqrt(2) * (basis(10, 4) + basis(10, 2))
+xvec = np.arange(-5, 5, 10.0 / 100)
+yvec = xvec
+W = wigner(x, xvec, yvec)
+cmap = wigner_cmap(W)
+X, Y = np.meshgrid(xvec, yvec)
+```
+
+```python
+fig = plt.figure(figsize=(8, 6))
+plt.contourf(X, Y, W, 50, cmap=cmap)
+plt.colorbar();
+```
+
+```python
+fig = plt.figure(figsize=(10, 8))
+ax = Axes3D(fig, azim=-30, elev=73)
+ax.plot_surface(X, Y, W, cmap=cmap, rstride=1, cstride=1, alpha=1, linewidth=0)
+ax.set_zlim3d(-0.25, 0.25)
+for a in ax.w_zaxis.get_ticklines() + ax.w_zaxis.get_ticklabels():
+    a.set_visible(False)
+nrm = mpl.colors.Normalize(W.min(), W.max())
+cax, kw = mpl.colorbar.make_axes(ax, shrink=0.66, pad=0.02)
+cb1 = mpl.colorbar.ColorbarBase(cax, cmap=cmap, norm=nrm)
+cb1.set_label("Pseudoprobability")
+```
+
+## Winger and Q-function for squeezed states
+
+```python
+N = 20
+alpha = -1.0  # Coherent amplitude of field
+epsilon = 0.5j  # Squeezing parameter
+a = destroy(N)
+
+D = (alpha * a.dag() - np.conj(alpha) * a).expm()  # Displacement
+S = (
+    0.5 * np.conj(epsilon) * a * a - 0.5 * epsilon * a.dag() * a.dag()
+).expm()  # Squeezing
+psi = D * S * basis(N, 0)  # Apply to vacuum state
+g = 2
+```
+
+### Wigner function
+
+```python
+xvec = np.arange(-40.0, 40.0) * 5.0 / 40
+X, Y = np.meshgrid(xvec, xvec)
+
+W = wigner(psi, xvec, xvec)
+
+fig1 = plt.figure(figsize=(8, 6))
+ax = Axes3D(fig1)
+ax.plot_surface(X, Y, W, rstride=2, cstride=2, cmap=cm.jet, alpha=0.7)
+ax.contour(X, Y, W, 15, zdir="x", offset=-6)
+ax.contour(X, Y, W, 15, zdir="y", offset=6)
+ax.contour(X, Y, W, 15, zdir="z", offset=-0.3)
+ax.set_xlim3d(-6, 6)
+ax.set_xlim3d(-6, 6)
+ax.set_zlim3d(-0.3, 0.4)
+plt.title("Wigner function of squeezed state");
+```
+
+### Q-function
+
+```python
+Q = qfunc(psi, xvec, xvec, g)
+
+fig2 = plt.figure(figsize=(8, 6))
+ax = Axes3D(fig2)
+ax.plot_surface(X, Y, Q, rstride=2, cstride=2, cmap=cm.jet, alpha=0.7)
+ax.contour(X, Y, Q, zdir="x", offset=-6)
+ax.contour(X, Y, Q, zdir="y", offset=6)
+ax.contour(X, Y, Q, 15, zdir="z", offset=-0.4)
+ax.set_xlim3d(-6, 6)
+ax.set_xlim3d(-6, 6)
+ax.set_zlim3d(-0.3, 0.4)
+plt.title("Q function of squeezed state");
+```
+
+## Schrodinger cat state
+
+```python
+N = 20
+# amplitudes of coherent states
+alpha1 = -2.0 - 2j
+alpha2 = 2.0 + 2j
+# define ladder oeprators
+a = destroy(N)
+# define displacement oeprators
+D1 = (alpha1 * a.dag() - np.conj(alpha1) * a).expm()
+D2 = (alpha2 * a.dag() - np.conj(alpha2) * a).expm()
+# sum of coherent states
+psi = np.sqrt(2) ** -1 * (D1 + D2) * basis(N, 0);  # Apply to vacuum state
+```
+
+```python
+# calculate Wigner function
+yvec = xvec = np.arange(-100.0, 100.0) * 5.0 / 100
+g = 2.0
+W = wigner(psi, xvec, yvec)
+fig = plt.figure(figsize=(8, 6))
+c = plt.contourf(xvec, yvec, np.real(W), 100)
+plt.xlim([-5, 5])
+plt.ylim([-5, 5])
+plt.title("Wigner function of Schrodinger cat")
+cbar = plt.colorbar(c)
+cbar.ax.set_ylabel("Pseudoprobability");
+```
+
+```python
+# calculate Q function
+Q = qfunc(psi, xvec, yvec)
+fig = plt.figure(figsize=(8, 6))
+qplt = plt.contourf(xvec, yvec, np.real(Q), 100)
+plt.xlim([-5, 5])
+plt.ylim([-5, 5])
+plt.title("Q function of Schrodinger cat")
+cbar = plt.colorbar(qplt)
+cbar.ax.set_ylabel("Probability");
+```
+
+## Software version:
+
+```python
+about()
+```

--- a/tutorials-v5/visualization/quantum-process-tomography.md
+++ b/tutorials-v5/visualization/quantum-process-tomography.md
@@ -1,0 +1,115 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# QuTiP example: Quantum Process Tomography
+
+
+J.R. Johansson and P.D. Nation
+
+For more information about QuTiP see [http://qutip.org](http://qutip.org)
+
+```python
+import numpy as np
+from qutip import (about, qeye, qpt, qpt_plot_combined, sigmax, sigmay, sigmaz,
+                   spost, spre)
+from qutip_qip.operations import (cnot, fredkin, iswap, phasegate, snot,
+                                  sqrtiswap, swap, toffoli)
+
+%matplotlib inline
+```
+
+```python
+"""
+Plot the process tomography matrices for some 1, 2, and 3-qubit qubit gates.
+"""
+gates = [
+    ["C-NOT", cnot()],
+    ["SWAP", swap()],
+    ["$i$SWAP", iswap()],
+    [r"$\sqrt{i\mathrm{SWAP}}$", sqrtiswap()],
+    ["S-NOT", snot()],
+    [r"$\pi/2$ phase gate", phasegate(np.pi / 2)],
+    ["Toffoli", toffoli()],
+    ["Fredkin", fredkin()],
+]
+```
+
+```python
+def plt_qpt_gate(gate, figsize=(8, 6)):
+
+    name = gate[0]
+    U_psi = gate[1]
+
+    N = len(U_psi.dims[0])  # number of qubits
+
+    # create a superoperator for the density matrix
+    # transformation rho = U_psi * rho_0 * U_psi.dag()
+    U_rho = spre(U_psi) * spost(U_psi.dag())
+
+    # operator basis for the process tomography
+    op_basis = [[qeye(2), sigmax(), sigmay(), sigmaz()] for i in range(N)]
+
+    # labels for operator basis
+    op_label = [["$i$", "$x$", "$y$", "$z$"] for i in range(N)]
+
+    # calculate the chi matrix
+    chi = qpt(U_rho, op_basis)
+
+    # visualize the chi matrix
+    fig, ax = qpt_plot_combined(chi, op_label, name, figsize=figsize)
+
+    ax.set_title(name)
+
+    return fig, ax
+```
+
+```python
+plt_qpt_gate(gates[0]);
+```
+
+```python
+plt_qpt_gate(gates[1]);
+```
+
+```python
+plt_qpt_gate(gates[2]);
+```
+
+```python
+plt_qpt_gate(gates[3]);
+```
+
+```python
+plt_qpt_gate(gates[4]);
+```
+
+```python
+plt_qpt_gate(gates[5]);
+```
+
+```python
+fig, ax = plt_qpt_gate(gates[6], figsize=(16, 12))
+ax.axis("tight");
+```
+
+```python
+fig, ax = plt_qpt_gate(gates[7], figsize=(16, 12))
+ax.axis("tight");
+```
+
+## Versions
+
+```python
+about()
+```

--- a/tutorials-v5/visualization/qubism-and-schmidt-plots.md
+++ b/tutorials-v5/visualization/qubism-and-schmidt-plots.md
@@ -1,0 +1,442 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# QuTiP example: Qubism visualizations
+
+
+by [Piotr Migdał](http://migdal.wikidot.com/), June 2014
+
+For more information about QuTiP see http://qutip.org.
+
+For more information about Qubism see:
+* J. Rodriguez-Laguna, P. Migdał, M. Ibanez Berganza, M. Lewenstein, G. Sierra,
+  [Qubism: self-similar visualization of many-body wavefunctions](http://dx.doi.org/10.1088/1367-2630/14/5/053028), New J. Phys. 14 053028 (2012), [arXiv:1112.3560](http://arxiv.org/abs/1112.3560),
+* [its video abstract](https://www.youtube.com/watch?v=8fPAzOziTZo),
+* [C++ and Mathematica code on GitHub](https://github.com/stared/qubism).
+
+This note describes plotting functions `plot_schmidt` and `plot_qubism`, and additionally - `complex_array_to_rgb`, along with their applications.
+
+
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from qutip import (Qobj, about, complex_array_to_rgb, jmat, ket, plot_qubism,
+                   plot_schmidt, qeye, sigmax, sigmay, sigmaz, tensor)
+
+%matplotlib inline
+```
+
+## Colors
+
+
+In quantum mechanics, complex numbers are as natual as real numbers.
+
+Before going into details of particular plots, we show how `complex_array_to_rgb` maps $z = x + i y$ into colors.
+There are two variants, `theme='light'` and `theme='dark'`. For both, we use hue for phase, with red for positive numbers and aqua for negative.
+
+For a longer comment on coloring complex functions I recommend IPython Notebook [Visualizing complex-valued functions with Matplotlib and Mayavi](http://nbviewer.ipython.org/github/empet/Math/blob/master/DomainColoring.ipynb) by Emilia Petrisor.
+
+```python
+compl_circ = np.array(
+    [
+        [(x + 1j * y) if x ** 2 + y**2 <= 1 else 0j
+            for x in np.arange(-1, 1, 0.005)]
+        for y in np.arange(-1, 1, 0.005)
+    ]
+)
+
+fig = plt.figure(figsize=(6, 3))
+for i, theme in enumerate(["light", "dark"]):
+    ax = plt.subplot(1, 2, i + 1)
+    ax.set_xlabel("x", fontsize=14)
+    ax.set_ylabel("y", fontsize=14)
+    ax.imshow(
+        complex_array_to_rgb(compl_circ, rmax=1, theme=theme),
+        extent=(-1, 1, -1, 1)
+    )
+plt.tight_layout()
+```
+
+## Schmidt plot
+
+
+Arguably, the easiest way to show entanglement is to plot a wavefunction against two variables.
+If the plot is a product of them, the state is a product state. If not - it is entangled.
+
+As writing a wavefunction as a matrix $|\psi\rangle_{ij}$ is the the crucial step in [Schmidt decomposition](http://en.wikipedia.org/wiki/Schmidt_decomposition),
+we call such plots Schmidt plots.
+
+Let us consider two states:
+
+* entangled: singlet state $|\psi^-\rangle = (|01\rangle - |10\rangle)/\sqrt{2}$,
+* product $(|01\rangle - |00\rangle)/\sqrt{2}$.
+
+They may look seamingly similar, but the later can be decomposed into a product $|0\rangle(|1\rangle - |0\rangle)/\sqrt{2}$.
+
+```python
+singlet = (ket("01") - ket("10")).unit()
+separable = (ket("01") - ket("00")).unit()
+```
+
+```python
+plot_schmidt(singlet, figsize=(2, 2));
+```
+
+```python
+plot_schmidt(separable, figsize=(2, 2));
+```
+
+As we see, for separable state the plot is a product of `x` and `y` coordinates, while for the singlet state - is is not.
+
+Let us now consider a product of two singlet states: $|\psi^-\rangle|\psi^-\rangle$.
+Schmidt plot, by default, makes spliting of equal numbers of particles.
+
+(And just for fun, let's multiply it by the imaginary unit, to get diffeerent colors.)
+
+```python
+plot_schmidt(1j * tensor([singlet, singlet]), figsize=(2, 2));
+```
+
+As we see, we have a product, as the state is a product state with the respect to the splitting of first 2 vs last 2 particles.
+
+But what if we shift particles, getting $|\psi^-\rangle_{23}|\psi^-\rangle_{41}$?
+
+```python
+plot_schmidt(1j * tensor([singlet, singlet]).permute([1, 2, 3, 0]),
+             figsize=(2, 2));
+```
+
+So we see that it is entangled.
+
+`plot_schmidt` allows us to specify other splittings. With parameter `splitting` we decide how many particles we want to have as columns. In general, we can plot systems of various numbers of particles, each being of a different dimension.
+
+For example:
+
+```python
+plot_schmidt(
+    1j * tensor([singlet, singlet]),
+    splitting=1,
+    labels_iteration=(1, 3),
+    figsize=(4, 2),
+);
+```
+
+## Qubism plot
+
+```python
+fig = plt.figure(figsize=(8, 4))
+for i in [1, 2]:
+    ax = plt.subplot(1, 2, i)
+    plot_qubism(0 * ket("0000"), legend_iteration=i, grid_iteration=i,
+                fig=fig, ax=ax)
+```
+
+That is, all amplitudes for states starting with:
+
+* $|00\rangle$ go to the upper left quadrant,
+* $|01\rangle$ go to the upper right quadrant,
+* $|10\rangle$ go to the lower left quadrant,
+* $|11\rangle$ go to the lower right quadrant.
+
+And we proceed recursively with the next particles. So, for example:
+
+```python
+state = (
+    ket("0010")
+    + 0.5 * ket("1111")
+    + 0.5j * ket("0101")
+    - 1j * ket("1101")
+    - 0.2 * ket("0110")
+)
+plot_qubism(state, figsize=(4, 4));
+```
+
+Or if we want to make sure how did we map amplitudes to particular regions in the plot:
+
+```python
+plot_qubism(state, legend_iteration=2, figsize=(4, 4));
+```
+
+Or how about making it dark? (E.g. to fit out slides with black background).
+
+```python
+plot_qubism(state, legend_iteration=2, theme="dark", figsize=(4, 4));
+```
+
+The most important property of Qubism is the recursive structure. So that we can add more particles seamlessly.
+For example, let's consider a plot of `k` copies of the singlet states, i.e. $|\psi^-\rangle^{\otimes k}$:
+
+```python
+fig = plt.figure(figsize=(15, 3))
+for k in range(1, 6):
+    ax = plt.subplot(1, 5, k)
+    plot_qubism(tensor([singlet] * k), fig=fig, ax=ax)
+```
+
+OK, but once we can type the wavefunction by hand, plots offer little added value.
+
+Let's see how we can plot ground states.
+Before doing that, we define some functions to easy make a translationally-invariant Hamiltonian.
+
+```python
+def spinchainize(op, n, bc="periodic"):
+
+    if isinstance(op, list):
+        return sum([spinchainize(each, n, bc=bc) for each in op])
+
+    k = len(op.dims[0])
+    d = op.dims[0][0]
+
+    expanded = tensor([op] + [qeye(d)] * (n - k))
+
+    if bc == "periodic":
+        shifts = n
+    elif bc == "open":
+        shifts = n - k + 1
+
+    shifteds = [
+        expanded.permute([(i + j) % n for i in range(n)])
+        for j in range(shifts)
+    ]
+
+    return sum(shifteds)
+
+
+def gs_of(ham):
+    gval, gstate = ham.groundstate()
+    return gstate
+```
+
+For example, let us consider Hamiltonian for $N$ particles, of the following form (a generalization of the [Majumdar-Ghosh model](http://en.wikipedia.org/wiki/Majumdar%E2%80%93Ghosh_Model)):
+
+$$H = \sum_{i=1}^N \vec{S}_i \cdot \vec{S}_{i+1} + J \sum_{i=1}^N \vec{S}_i \cdot \vec{S}_{i+2},$$
+
+where $\vec{S}_i = \tfrac{1}{2} (\sigma^x, \sigma^y, \sigma^z)$ is the spin operator (with sigmas being [Pauli matrices](http://en.wikipedia.org/wiki/Pauli_matrices)).
+
+Moreover, we can set two different boundary conditions:
+
+* periodic - spin chain forms a loop ($N+1 \equiv 1$ and $N+2 \equiv 2$),
+* open - spin chain forms a line (we remove terms with $N+1$ and $N+2$).
+
+```python
+heis = sum([tensor([pauli] * 2) for pauli in [sigmax(), sigmay(), sigmaz()]])
+heis2 = sum(
+    [tensor([pauli, qeye(2), pauli])
+     for pauli in [sigmax(), sigmay(), sigmaz()]]
+)
+
+N = 10
+Js = [0.0, 0.5, 1.0]
+
+fig = plt.figure(figsize=(2 * len(Js), 4.4))
+
+for b in [0, 1]:
+    for k, J in enumerate(Js):
+        ax = plt.subplot(2, len(Js), b * len(Js) + k + 1)
+
+        if b == 0:
+            spinchain = spinchainize([heis, J * heis2], N, bc="periodic")
+        elif b == 1:
+            spinchain = spinchainize([heis, J * heis2], N, bc="open")
+
+        plot_qubism(gs_of(spinchain), ax=ax)
+
+        if k == 0:
+            if b == 0:
+                ax.set_ylabel("periodic BC", fontsize=16)
+            else:
+                ax.set_ylabel("open BC", fontsize=16)
+        if b == 1:
+            ax.set_xlabel("$J={0:.1f}$".format(J), fontsize=16)
+
+plt.tight_layout()
+```
+
+We are not restricted to qubits. We can have it for other dimensions, e.g. qutrits.
+
+Let us consider [AKLT model](http://en.wikipedia.org/wiki/AKLT_Model) for spin-1 particles:
+
+$$H = \sum_{i=1}^N \vec{S}_i \cdot \vec{S}_{i+1} + \tfrac{1}{3} \sum_{i=1}^N (\vec{S}_i \cdot \vec{S}_{i+1})^2.$$
+
+where $\vec{S}_i$ is [spin operator](http://en.wikipedia.org/wiki/Pauli_matrices#Physics) for spin-1 particles (or for `qutip`: `jmat(1, 'x')`, `jmat(1, 'y')` and `jmat(1, 'z')`).
+
+```python
+ss = sum([tensor([jmat(1, s)] * 2) for s in ["x", "y", "z"]])
+H = spinchainize([ss, (1.0 / 3.0) * ss**2], n=6, bc="periodic")
+plot_qubism(gs_of(H), figsize=(4, 4));
+```
+
+Qubism for qutrits works similarly as for qubits:
+
+```python
+fig = plt.figure(figsize=(10, 5))
+for i in [1, 2]:
+    ax = plt.subplot(1, 2, i)
+    plot_qubism(
+        0 * ket("0000", dim=3), legend_iteration=i, grid_iteration=i,
+        fig=fig, ax=ax
+    )
+```
+
+Just in this case we interpret:
+
+* 0 as $s_z=-1$,
+* 1 as $s_z=\ \ 0$,
+* 2 as $s_z=+1$.
+
+While qubism works best for translationally-invariants states (so in particular, all particles need to have the same dimension), we can do it for others.
+
+Also, there are a few other Qubism-related plotting schemes. For example `how='pairs_skewed'`:
+
+```python
+fig = plt.figure(figsize=(8, 4))
+for i in [1, 2]:
+    ax = plt.subplot(1, 2, i)
+    plot_qubism(
+        0 * ket("0000"),
+        how="pairs_skewed",
+        legend_iteration=i,
+        grid_iteration=i,
+        fig=fig,
+        ax=ax,
+    )
+```
+
+The one above emphasis ferromagnetic (put on the left) vs antiferromagnetic (put on the right) states.
+
+Another one `how='before_after'` (inspired by [this](http://commons.wikimedia.org/wiki/File:Ising-tartan.png)) works in a bit different way: it uses typical recursion, but starting from middle particles. For example, the top left quadrant correspons to $|00\rangle_{N/2,N/2+1}$: 
+
+```python
+fig = plt.figure(figsize=(8, 4))
+for i in [1, 2]:
+    ax = plt.subplot(1, 2, i)
+    plot_qubism(
+        0 * ket("0000"),
+        how="before_after",
+        legend_iteration=i,
+        grid_iteration=i,
+        fig=fig,
+        ax=ax,
+    )
+```
+
+It is very similar to the Schmidt plot (for the default splitting), with the only difference being ordering of the `y` axis (particle order is reversed). All entanglement properties are the same.
+
+So how does it work on the same example? 
+Well, let us take spin chain for (Majumdar-Ghosh model for $J=0$), i.e.
+$$H = \sum_{i=1}^N \vec{S}_i \cdot \vec{S}_{i+1}$$
+for qubits.
+
+```python
+heis = sum([tensor([pauli] * 2) for pauli in [sigmax(), sigmay(), sigmaz()]])
+N = 10
+gs = gs_of(spinchainize(heis, N, bc="periodic"))
+
+fig = plt.figure(figsize=(12, 4))
+for i, how in enumerate(["schmidt_plot", "pairs",
+                         "pairs_skewed", "before_after"]):
+    ax = plt.subplot(1, 4, i + 1)
+    if how == "schmidt_plot":
+        plot_schmidt(gs, fig=fig, ax=ax)
+    else:
+        plot_qubism(gs, how=how, fig=fig, ax=ax)
+    ax.set_title(how)
+plt.tight_layout()
+```
+
+## Seeing entanglement
+
+```python
+product_1 = ket("0000")
+product_2 = tensor([(ket("0") + ket("1")).unit()] * 4)
+w = (ket("0001") + ket("0010") + ket("0100") + ket("1000")).unit()
+dicke_2of4 = (
+    ket("0011") + ket("0101") + ket("0110") +
+    ket("1001") + ket("1010") + ket("1100")
+).unit()
+ghz = (ket("0000") + ket("1111")).unit()
+```
+
+```python
+states = ["product_1", "product_2", "w", "dicke_2of4", "ghz"]
+fig = plt.figure(figsize=(2 * len(states), 2))
+for i, state_str in enumerate(states):
+    ax = plt.subplot(1, len(states), i + 1)
+    plot_qubism(eval(state_str), fig=fig, ax=ax)
+    ax.set_title(state_str)
+plt.tight_layout()
+```
+
+Then entanglement (or exactly: Schmidt rank) for a given partition is equal to number to different, non-zero squares. (We don't allow rotations, we do allow multiplication by a factor and, what may be more tricky, linear superposition.)
+
+Here we use partition of first 2 particles vs last 2, as indicated by lines.
+
+That is,
+* `product_1` - only 1 non-zero square: Schmidt rank 1,
+* `product_2` - 4 non-zero squares, but they are the same: Schmidt rank 1,
+* `w` - 3 non-zero quares, but two of them are the same: Schmidt rank 2,
+* `dicke_2of4` - 4 non-zero squares, but two of them are the same: Schmidt rank 3,
+* `ghz` - 2 non-zero squares, each one different: Schmidt rank 2.
+
+This is basis-independent, but it may be easier to work in one basis rather than another.
+
+And for a comparision, let us see product states:
+
+$$\left( \cos(\theta/2) |0\rangle + \sin(\theta/2) e^{i \varphi} |1\rangle \right)^N $$
+
+```python
+def product_state(theta, phi=0, n=1):
+    single = Qobj([[np.cos(theta / 2.0)],
+                   [np.sin(theta / 2.0) * np.exp(1j * phi)]])
+    return tensor([single] * n)
+
+
+thetas = 0.5 * np.pi * np.array([0.0, 0.5, 0.75, 1.0])
+phis = np.pi * np.array([0.0, 0.1, 0.2, 0.3])
+
+fig, axes2d = plt.subplots(nrows=len(phis),
+                           ncols=len(thetas), figsize=(6, 6))
+
+for i, row in enumerate(axes2d):
+    for j, cell in enumerate(row):
+        plot_qubism(
+            product_state(thetas[j], phi=phis[i], n=8),
+            grid_iteration=1, ax=cell
+        )
+        if i == len(axes2d) - 1:
+            cell.set_xlabel(
+                r"$\theta={0:s}\pi$".format(
+                    ["0", "(1/4)", "(3/8)", "(1/2)"][j]),
+                fontsize=16,
+            )
+        if j == 0:
+            cell.set_ylabel(
+                r"$\varphi={0:.1f}\pi$".format(phis[i] / np.pi), fontsize=16
+            )
+
+plt.tight_layout()
+```
+
+In each plot squares are the same, up to a factor (which is visualized as intensity and hue).
+
+You can lookup previous plots. Setting `grid_iteration=2` would show splitting of the first 4 particles vs N-4 others.
+And for `how='before_after'` it is the middle particles vs all others.
+
+
+### Versions
+
+```python
+about()
+```

--- a/tutorials-v5/visualization/visualization-exposition.md
+++ b/tutorials-v5/visualization/visualization-exposition.md
@@ -1,0 +1,189 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+# Development notebook for testing the visualization module in QuTiP
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import qutip as qt
+from qutip import about, basis, identity, sigmax, sigmay, sigmaz
+
+%matplotlib inline
+```
+
+## Hinton
+
+```python
+rho = qt.rand_dm(5)
+```
+
+```python
+qt.hinton(rho);
+```
+
+## Sphereplot
+
+```python
+theta = np.linspace(0, np.pi, 90)
+phi = np.linspace(0, 2 * np.pi, 60)
+```
+
+```python
+qt.sphereplot(theta, phi, qt.orbital(theta, phi, basis(3, 0)).T);
+```
+
+```python
+fig = plt.figure(figsize=(16, 4))
+
+ax = fig.add_subplot(1, 3, 1, projection="3d")
+qt.sphereplot(theta, phi, qt.orbital(theta, phi, basis(3, 0)).T, fig, ax)
+
+ax = fig.add_subplot(1, 3, 2, projection="3d")
+qt.sphereplot(theta, phi, qt.orbital(theta, phi, basis(3, 1)).T, fig, ax)
+
+ax = fig.add_subplot(1, 3, 3, projection="3d")
+qt.sphereplot(theta, phi, qt.orbital(theta, phi, basis(3, 2)).T, fig, ax);
+```
+
+# Matrix histogram
+
+```python
+qt.matrix_histogram(rho.full().real);
+```
+
+```python
+qt.matrix_histogram_complex(rho.full());
+```
+
+# Plot energy levels
+
+```python
+H0 = qt.tensor(sigmaz(), identity(2)) + qt.tensor(identity(2), sigmaz())
+Hint = 0.1 * qt.tensor(sigmax(), sigmax())
+
+qt.plot_energy_levels([H0, Hint], figsize=(8, 4));
+```
+
+# Plot Fock distribution
+
+```python
+rho = (qt.coherent(15, 1.5) + qt.coherent(15, -1.5)).unit()
+```
+
+```python
+qt.plot_fock_distribution(rho);
+```
+
+# Plot Wigner function and Fock distribution
+
+```python
+qt.plot_wigner_fock_distribution(rho);
+```
+
+# Plot winger function
+
+```python
+qt.plot_wigner(rho, figsize=(6, 6));
+```
+
+# Plot expectation values
+
+```python
+H = sigmaz() + 0.3 * sigmay()
+e_ops = [sigmax(), sigmay(), sigmaz()]
+times = np.linspace(0, 10, 100)
+psi0 = (basis(2, 0) + basis(2, 1)).unit()
+result = qt.mesolve(H, psi0, times, [], e_ops)
+```
+
+```python
+qt.plot_expectation_values(result);
+```
+
+# Bloch sphere
+
+```python
+b = qt.Bloch()
+b.add_vectors(qt.expect(H.unit(), e_ops))
+b.add_points(result.expect, meth="l")
+b.make_sphere()
+```
+
+# Plot spin Q-functions
+
+```python
+j = 5
+psi = qt.spin_state(j, -j)
+psi = qt.spin_coherent(j, np.random.rand() * np.pi,
+                       np.random.rand() * 2 * np.pi)
+rho = qt.ket2dm(psi)
+```
+
+```python
+theta = np.linspace(0, np.pi, 50)
+phi = np.linspace(0, 2 * np.pi, 50)
+```
+
+```python
+Q, THETA, PHI = qt.spin_q_function(psi, theta, phi)
+```
+
+## 2D
+
+```python
+qt.plot_spin_distribution_2d(Q, THETA, PHI);
+```
+
+## 3D
+
+```python
+fig, ax = qt.plot_spin_distribution_3d(Q, THETA, PHI)
+
+ax.view_init(15, 30)
+```
+
+## Combined 2D and 3D
+
+```python
+fig = plt.figure(figsize=(14, 6))
+
+ax = fig.add_subplot(1, 2, 1)
+f1, a1 = qt.plot_spin_distribution_2d(Q, THETA, PHI, fig=fig, ax=ax)
+
+ax = fig.add_subplot(1, 2, 2, projection="3d")
+f2, a2 = qt.plot_spin_distribution_3d(Q, THETA, PHI, fig=fig, ax=ax)
+```
+
+# Plot spin-Wigner functions
+
+```python
+W, THETA, PHI = qt.spin_wigner(psi, theta, phi)
+```
+
+```python
+fig = plt.figure(figsize=(14, 6))
+
+ax = fig.add_subplot(1, 2, 1)
+f1, a1 = qt.plot_spin_distribution_2d(W.real, THETA, PHI, fig=fig, ax=ax)
+
+ax = fig.add_subplot(1, 2, 2, projection="3d")
+f2, a2 = qt.plot_spin_distribution_3d(W.real, THETA, PHI, fig=fig, ax=ax)
+```
+
+# Versions
+
+```python
+about()
+```


### PR DESCRIPTION
This PR adds all tutorials on visualization for QuTiP 4 and QuTiP 5. All notebooks are taken from [here](https://qutip.org/tutorials.html) and were only changed slightly to work with the corresponding versions of QuTiP.

There are two problems with the tutorials:

- In QuTiP 5 the notebook the colorbar attached to a Bloch sphere plot is not displayed correctly. This is dealt with in https://github.com/qutip/qutip/issues/1913
- In the notebook `visual-exposition.md` some DeprecationWarning is raised by `matplotlib`, but it does not (yet) block the correct execution of the notebook. This issue is described in https://github.com/qutip/qutip/issues/1973