### PR TITLE
Fix URL for nbviewer

### DIFF
--- a/website/create_index.py
+++ b/website/create_index.py
@@ -13,10 +13,11 @@ def natural_keys(text):
 
 class notebook:
     def __init__(self, path, title):
-        self.path = path
+        # remove ../ from path
+        self.path = path.replace('../', '')
         self.title = title
         # set url and update from markdown to ipynb
-        self.url = url_prefix + path.replace(".md", ".ipynb")
+        self.url = url_prefix + self.path.replace(".md", ".ipynb")
 
 
 def get_title(filename):


### PR DESCRIPTION
There is a small bug with the url passed to nbviewer to display the notebooks. This PR fixes this problem, which is due to a `../` in the path of each notebook.