### PR TITLE
Update broken links and add cython to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - matplotlib==3.5.2
 - imagemagick==7.1.0_36
 - qutip==4.7.0
+- cython==0.29.32
 - notebook==6.4.11
 - jupytext==1.13.8
 - pip:

--- a/tutorials-v4/python-introduction/003_Matplotlib_Plotting.md
+++ b/tutorials-v4/python-introduction/003_Matplotlib_Plotting.md
@@ -264,7 +264,7 @@ Additional Sources of Information
 
 - [Matplotlib Examples](http://matplotlib.org/examples/index.html) : A long list of examples demonstrating how to use Matplotlib for a variety of plotting.
 
-- [Guide to 2D & 3D Plotting](http://nbviewer.ipython.org/github/jrjohansson/scientific-python-lectures/blob/master/Lecture-4-Matplotlib.ipynb) : A guide for plotting in Matplotlib by Robert Johansson.
+- [Guide to 2D & 3D Plotting](http://nbviewer.jupyter.org/github/jrjohansson/scientific-python-lectures/blob/master/Lecture-4-Matplotlib.ipynb) : A guide for plotting in Matplotlib by Robert Johansson.
 
 
 <h1 align="center">End of Tutorial</h1> 

--- a/tutorials-v4/quantum-circuits/teleportation.md
+++ b/tutorials-v4/quantum-circuits/teleportation.md
@@ -24,7 +24,7 @@ from qutip_qip.operations import Measurement
 
 ## Introduction 
 
-This notebook introduces the basic quantum teleportation circuit (http://www.physics.udel.edu/~msafrono/425-2011/Lecture%2025-1.pdf), complete with measurements and classical control. This notebook also serves as an example on how to add measurement gates and classical controls to a circuit.
+This notebook introduces the basic quantum teleportation circuit (https://en.wikipedia.org/wiki/Quantum_teleportation), complete with measurements and classical control. This notebook also serves as an example on how to add measurement gates and classical controls to a circuit.
 
 We will describe the circuit that enables quantum teleportation. We will use two classical wires and three qubit wires. The first qubit wire represents the quantum state $| q0 ⟩ = | \psi ⟩$ that needs to be transferred from Alice to Bob (so the first qubit is in the possession of Alice). 
 

--- a/tutorials-v4/time-evolution/002_larmor-precession.md
+++ b/tutorials-v4/time-evolution/002_larmor-precession.md
@@ -86,7 +86,7 @@ b.show()
 ## Simulation with varying magnetic field
 
 Above we passed a constant Hamiltonian to `sesolve`. In QuTiP these constant operators are represented by `Qobj`. However, `sesolve` can also take time-dependent operators as an argument, which are represented by [`QobjEvo`](https://qutip.org/docs/latest/apidoc/classes.html?highlight=qobjevo#qutip.QobjEvo) in QuTiP. In this section we define the magnetic field with a linear and a periodic field strength, and observe the changes in the expecation value of $\sigma_y$.
-You can find more information on `QobjEvo` in [this notebook](https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qobjevo.ipynb).
+You can find more information on `QobjEvo` in [this notebook](https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/qobjevo.ipynb).
 
 We start by defining two functions for the field strength of the magnetic field. To be passed on to `QobjEvo` the functions need two arguments: the times and optional arguments.
 

--- a/tutorials-v4/time-evolution/006_photon_birth_death.md
+++ b/tutorials-v4/time-evolution/006_photon_birth_death.md
@@ -125,5 +125,4 @@ about()
 ```python
 np.testing.assert_allclose(me.expect[0], mc.expect[3][0], atol=10**-1)
 assert np.all(np.diff(me.expect[0]) <= 0)
-np.testing.assert_allclose(mc.expect[0][0], mc.expect[0][0].astype(bool))
 ```

--- a/tutorials-v4/time-evolution/006_photon_birth_death.md
+++ b/tutorials-v4/time-evolution/006_photon_birth_death.md
@@ -125,6 +125,6 @@ about()
 ```python
 np.testing.assert_allclose(me.expect[0], mc.expect[3][0], atol=10**-1)
 assert np.all(np.diff(me.expect[0]) <= 0)
-np.testing.assert_array_equal(np.round(mc.expect[0][0], 4),
-                              mc.expect[0][0].astype(bool))
+np.testing.assert_allclose(mc.expect[0][0],
+                                mc.expect[0][0].astype(bool))
 ```

--- a/tutorials-v4/time-evolution/006_photon_birth_death.md
+++ b/tutorials-v4/time-evolution/006_photon_birth_death.md
@@ -5,7 +5,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.13.8
+      jupytext_version: 1.14.1
   kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
@@ -125,6 +125,5 @@ about()
 ```python
 np.testing.assert_allclose(me.expect[0], mc.expect[3][0], atol=10**-1)
 assert np.all(np.diff(me.expect[0]) <= 0)
-np.testing.assert_allclose(mc.expect[0][0],
-                                mc.expect[0][0].astype(bool))
+np.testing.assert_allclose(mc.expect[0][0], mc.expect[0][0].astype(bool))
 ```

--- a/tutorials-v4/time-evolution/015_smesolve-heterodyne.md
+++ b/tutorials-v4/time-evolution/015_smesolve-heterodyne.md
@@ -357,7 +357,7 @@ result = smesolve(
 ```
 
 ```python
-result.states[0][100]
+result.states[0][100].full()
 ```
 
 ```python

--- a/tutorials-v4/visualization/qubism-and-schmidt-plots.md
+++ b/tutorials-v4/visualization/qubism-and-schmidt-plots.md
@@ -46,7 +46,7 @@ In quantum mechanics, complex numbers are as natual as real numbers.
 Before going into details of particular plots, we show how `complex_array_to_rgb` maps $z = x + i y$ into colors.
 There are two variants, `theme='light'` and `theme='dark'`. For both, we use hue for phase, with red for positive numbers and aqua for negative.
 
-For a longer comment on coloring complex functions I recommend IPython Notebook [Visualizing complex-valued functions with Matplotlib and Mayavi](http://nbviewer.ipython.org/github/empet/Math/blob/master/DomainColoring.ipynb) by Emilia Petrisor.
+For a longer comment on coloring complex functions I recommend IPython Notebook [Visualizing complex-valued functions with Matplotlib and Mayavi](http://nbviewer.jupyter.org/github/empet/Math/blob/master/DomainColoring.ipynb) by Emilia Petrisor.
 
 ```python
 compl_circ = np.array(

--- a/tutorials-v5/lectures/Lecture-4-Correlation-Functions.md
+++ b/tutorials-v5/lectures/Lecture-4-Correlation-Functions.md
@@ -5,7 +5,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.13.8
+      jupytext_version: 1.14.1
   kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
@@ -65,6 +65,10 @@ n = mesolve(H, rho0, taulist, c_ops, [a.dag() * a]).expect[0]
 
 # calculate the correlation function G1 and normalize with n to obtain g1
 G1 = correlation_2op_2t(H, rho0, None, taulist, c_ops, a.dag(), a)
+# extract taulist results
+if len(G1.shape) == 2:
+    G1 = G1[0]
+
 g1 = G1 / np.sqrt(n[0] * n)
 ```
 
@@ -294,8 +298,4 @@ axes.set_ylabel(r"LG($\tau$)", fontsize=18);
 
 ```python
 about()
-```
-
-```python
-
 ```

--- a/tutorials-v5/python-introduction/003_Matplotlib_Plotting.md
+++ b/tutorials-v5/python-introduction/003_Matplotlib_Plotting.md
@@ -264,7 +264,7 @@ Additional Sources of Information
 
 - [Matplotlib Examples](http://matplotlib.org/examples/index.html) : A long list of examples demonstrating how to use Matplotlib for a variety of plotting.
 
-- [Guide to 2D & 3D Plotting](http://nbviewer.ipython.org/github/jrjohansson/scientific-python-lectures/blob/master/Lecture-4-Matplotlib.ipynb) : A guide for plotting in Matplotlib by Robert Johansson.
+- [Guide to 2D & 3D Plotting](http://nbviewer.jupyter.org/github/jrjohansson/scientific-python-lectures/blob/master/Lecture-4-Matplotlib.ipynb) : A guide for plotting in Matplotlib by Robert Johansson.
 
 
 <h1 align="center">End of Tutorial</h1> 

--- a/tutorials-v5/quantum-circuits/teleportation.md
+++ b/tutorials-v5/quantum-circuits/teleportation.md
@@ -24,7 +24,7 @@ from qutip_qip.operations import Measurement
 
 ## Introduction 
 
-This notebook introduces the basic quantum teleportation circuit (http://www.physics.udel.edu/~msafrono/425-2011/Lecture%2025-1.pdf), complete with measurements and classical control. This notebook also serves as an example on how to add measurement gates and classical controls to a circuit.
+This notebook introduces the basic quantum teleportation circuit (https://en.wikipedia.org/wiki/Quantum_teleportation), complete with measurements and classical control. This notebook also serves as an example on how to add measurement gates and classical controls to a circuit.
 
 We will describe the circuit that enables quantum teleportation. We will use two classical wires and three qubit wires. The first qubit wire represents the quantum state $| q0 ⟩ = | \psi ⟩$ that needs to be transferred from Alice to Bob (so the first qubit is in the possession of Alice). 
 

--- a/tutorials-v5/time-evolution/002_larmor-precession.md
+++ b/tutorials-v5/time-evolution/002_larmor-precession.md
@@ -86,7 +86,7 @@ b.show()
 ## Simulation with varying magnetic field
 
 Above we passed a constant Hamiltonian to `sesolve`. In QuTiP these constant operators are represented by `Qobj`. However, `sesolve` can also take time-dependent operators as an argument, which are represented by [`QobjEvo`](https://qutip.org/docs/latest/apidoc/classes.html?highlight=qobjevo#qutip.QobjEvo) in QuTiP. In this section we define the magnetic field with a linear and a periodic field strength, and observe the changes in the expecation value of $\sigma_y$.
-You can find more information on `QobjEvo` in [this notebook](https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qobjevo.ipynb).
+You can find more information on `QobjEvo` in [this notebook](https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/qobjevo.ipynb).
 
 We start by defining two functions for the field strength of the magnetic field. To be passed on to `QobjEvo` the functions need two arguments: the times and optional arguments.
 

--- a/tutorials-v5/time-evolution/006_photon_birth_death.md
+++ b/tutorials-v5/time-evolution/006_photon_birth_death.md
@@ -121,6 +121,5 @@ about()
 ```python
 np.testing.assert_allclose(me.expect[0], mc.expect[3][0], atol=10**-1)
 assert np.all(np.diff(me.expect[0]) <= 0)
-np.testing.assert_allclose(mc.expect[0][0],
-                              mc.expect[0][0].astype(bool))
+np.testing.assert_allclose(mc.expect[0][0], mc.expect[0][0].astype(bool))
 ```

--- a/tutorials-v5/time-evolution/006_photon_birth_death.md
+++ b/tutorials-v5/time-evolution/006_photon_birth_death.md
@@ -5,7 +5,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.13.8
+      jupytext_version: 1.14.1
   kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
@@ -121,6 +121,6 @@ about()
 ```python
 np.testing.assert_allclose(me.expect[0], mc.expect[3][0], atol=10**-1)
 assert np.all(np.diff(me.expect[0]) <= 0)
-np.testing.assert_array_equal(np.round(mc.expect[0][0], 4),
+np.testing.assert_allclose(mc.expect[0][0],
                               mc.expect[0][0].astype(bool))
 ```

--- a/tutorials-v5/time-evolution/006_photon_birth_death.md
+++ b/tutorials-v5/time-evolution/006_photon_birth_death.md
@@ -121,5 +121,4 @@ about()
 ```python
 np.testing.assert_allclose(me.expect[0], mc.expect[3][0], atol=10**-1)
 assert np.all(np.diff(me.expect[0]) <= 0)
-np.testing.assert_allclose(mc.expect[0][0], mc.expect[0][0].astype(bool))
 ```

--- a/tutorials-v5/visualization/qubism-and-schmidt-plots.md
+++ b/tutorials-v5/visualization/qubism-and-schmidt-plots.md
@@ -46,7 +46,7 @@ In quantum mechanics, complex numbers are as natual as real numbers.
 Before going into details of particular plots, we show how `complex_array_to_rgb` maps $z = x + i y$ into colors.
 There are two variants, `theme='light'` and `theme='dark'`. For both, we use hue for phase, with red for positive numbers and aqua for negative.
 
-For a longer comment on coloring complex functions I recommend IPython Notebook [Visualizing complex-valued functions with Matplotlib and Mayavi](http://nbviewer.ipython.org/github/empet/Math/blob/master/DomainColoring.ipynb) by Emilia Petrisor.
+For a longer comment on coloring complex functions I recommend IPython Notebook [Visualizing complex-valued functions with Matplotlib and Mayavi](http://nbviewer.jupyter.org/github/empet/Math/blob/master/DomainColoring.ipynb) by Emilia Petrisor.
 
 ```python
 compl_circ = np.array(

--- a/website/index.html.jinja
+++ b/website/index.html.jinja
@@ -74,26 +74,26 @@ useful to have a look at these IPython notebook
 <p>This section requires an additional package <a href="https://github.com/qutip/qutip-qip">qutip-qip</a>.</p>
 <h5 id="quantum-circuits">Quantum circuits</h5>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/quantum-gates.ipynb">Quantum gates and circuits</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-toffoli-cnot.ipynb">Toffoli gate to CNOT</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qasm.ipynb">Importing and exporting QASM circuits</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/teleportation.ipynb">Quantum teleportation</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/quantum-gates.ipynb">Quantum gates and circuits</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/qip-toffoli-cnot.ipynb">Toffoli gate to CNOT</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/qasm.ipynb">Importing and exporting QASM circuits</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/teleportation.ipynb">Quantum teleportation</a> </li>
 </ul>
 
 <h5 id="nisq">Pulse-level circuit simulation</h5>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-processor-DJ-algorithm.ipynb">Simulating the Deutsch–Jozsa algorithm with noise</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-customize-device.ipynb">Customizing the pulse-level simulation</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-scheduler.ipynb">The pulse scheduler</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-relaxation-measurement-with-the-idling-gate.ipynb">Measuring the relaxation time</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-10-qubit-QFT-algorithm.ipynb">Simulating a 10-qubit QFT algorithm</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-randomized-benchmarking.ipynb">Simulating randomized benchmarking</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-optpulseprocessor.ipynb">Optimal pulse processor</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/qip-processor-DJ-algorithm.ipynb">Simulating the Deutsch–Jozsa algorithm with noise</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/qip-customize-device.ipynb">Customizing the pulse-level simulation</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/qip-scheduler.ipynb">The pulse scheduler</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/qip-relaxation-measurement-with-the-idling-gate.ipynb">Measuring the relaxation time</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/qip-10-qubit-QFT-algorithm.ipynb">Simulating a 10-qubit QFT algorithm</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/qip-randomized-benchmarking.ipynb">Simulating randomized benchmarking</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/qip-optpulseprocessor.ipynb">Optimal pulse processor</a> </li>
 </ul>
 
 <h4 id="piqs">Permutational invariant Lindblad dynamics</h4>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-overview.ipynb">Overview</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-overview.ipynb">Overview</a> </li>
 <li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-superradiant-light-emission.ipynb">Superradiant light emission</a> </li>
 <li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-steadystate-superradiance.ipynb">Steady state superradiance</a> </li>
 <li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-open-dicke-model.ipynb">Open Dicke model</a> </li>
@@ -117,27 +117,27 @@ useful to have a look at these IPython notebook
 
 <h4 id="optimal-control">Optimal control</h4>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/optimal-control-overview.ipynb">Overview</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-Hadamard.ipynb">Hadamard</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-QFT.ipynb">QFT</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-Lindbladian.ipynb">Lindbladian</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-symplectic.ipynb">Symplectic</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/control-pulseoptim-CRAB-QFT.ipynb">QFT (CRAB)</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/control-pulseoptim-CRAB-2qubitInerac.ipynb">State to state (CRAB)</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-cnot.ipynb">CNOT</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-iswap.ipynb">iSWAP</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-single-qubit-rotation.ipynb">Single-qubit rotation</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-toffoli.ipynb">Toffoli gate</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/optimal-control-overview.ipynb">Overview</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-Hadamard.ipynb">Hadamard</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-QFT.ipynb">QFT</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-Lindbladian.ipynb">Lindbladian</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-symplectic.ipynb">Symplectic</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/control-pulseoptim-CRAB-QFT.ipynb">QFT (CRAB)</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/control-pulseoptim-CRAB-2qubitInerac.ipynb">State to state (CRAB)</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-cnot.ipynb">CNOT</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-iswap.ipynb">iSWAP</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-single-qubit-rotation.ipynb">Single-qubit rotation</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-toffoli.ipynb">Toffoli gate</a> </li>
 </ul>
 
 <h4 id="tomography">Tomography</h4>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/tomography-iMLE-photon-counting.ipynb">Density matrix estimation with iterative maximum likelihood estimation</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/tomography-iMLE-photon-counting.ipynb">Density matrix estimation with iterative maximum likelihood estimation</a> </li>
 </ul>
 
 <h4 id="heom">Hierarchical Equations of Motion</h4>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/heom/heom-index.ipynb">Examples for solving the dynamics of systems coupled to bosonic and fermoinic baths using the Hierarchical Equations of Motion</a> </li>
+<li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/heom/heom-index.ipynb">Examples for solving the dynamics of systems coupled to bosonic and fermoinic baths using the Hierarchical Equations of Motion</a> </li>
 </ul>
 
 </div>
@@ -164,7 +164,7 @@ topics and analyze them numerically using QuTiP (some more detailed than others)
 <h3 id="development-nbs">Development notebooks</h3>
 <p>A collection of more technical development notebooks, which often focus on
 testing and benchmarking various features of QuTiP, is available
-<a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/tree/master/development/">here</a>.
+<a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/tree/master/development/">here</a>.
 </p>
 
 </div>


### PR DESCRIPTION
Minor fixes:

- Update the nbviewer links to use nbviewer.jupyter.org (nbviewer.ipython.org is deprecated and no longer works).
- Update the dead quantum teleportation reference with the Wikipedia article.
- Add Cython to the environment.yml, which is slightly friendlier to developers who might expect Cython to be installed when editing tutorials (see #46).