### PR TITLE
Pin ipykernel to 6.17.1 temporarily.

### DIFF
--- a/test_environment.yml
+++ b/test_environment.yml
@@ -12,3 +12,4 @@ dependencies:
 - nbmake==1.3.4
 - jupytext==1.13.8
 - jupyter==1.0.0
+- ipykernel==6.17.1  # 6.18.0 was yanked but is still present on conda-forge


### PR DESCRIPTION
The ipykernel 6.18.0 release was yanked from PyPI but is still present in conda-forge, so we need to pin the version in our test environment temporarily until upstream is fixed.