### PR TITLE
delete matrix_histogram_complex

### DIFF
--- a/tutorials-v5/visualization/visualization-exposition.md
+++ b/tutorials-v5/visualization/visualization-exposition.md
@@ -65,7 +65,8 @@ qt.matrix_histogram(rho.full().real);
 ```
 
 ```python
-qt.matrix_histogram_complex(rho.full());
+qt.matrix_histogram(rho.full(), limits=[0, 1],
+                    bar_style='abs', color_style='phase');
 ```
 
 # Plot energy levels


### PR DESCRIPTION
We removed ```matrix_histogram_complex```. I replaced it with ```matrix_histogram```. 
Related to [#2193](https://github.com/qutip/qutip/pull/2193)