### PR TITLE
Update tests parameters

### DIFF
--- a/.github/workflows/nightly_ci.yaml
+++ b/.github/workflows/nightly_ci.yaml
@@ -88,7 +88,7 @@ jobs:
     - name: Check PEP8 formatting
       run: |
         pip install nbqa flake8
-        find . -name '*.ipynb' -exec nbqa flake8 --max-line-length 88 {} +
+        find . -name '*.ipynb' -exec nbqa flake8 --max-line-length=88 {} +
 
     - name: Run tests
       run: |

--- a/.github/workflows/nightly_ci.yaml
+++ b/.github/workflows/nightly_ci.yaml
@@ -88,13 +88,13 @@ jobs:
     - name: Check PEP8 formatting
       run: |
         pip install nbqa flake8
-        find . -name '*.ipynb' -exec nbqa flake8 {} +
+        find . -name '*.ipynb' -exec nbqa flake8 --max-line-length 88 {} +
 
     - name: Run tests
       run: |
         jupyter kernel &
         cd notebooks
-        find . -name '*.ipynb' -exec pytest --nbmake --overwrite --nbmake-timeout=500 {} +
+        find . -name '*.ipynb' -exec pytest --nbmake --overwrite --nbmake-timeout=600 {} +
         rm template.ipynb
 
     - name: Create Notebook Artifact

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -21,9 +21,18 @@ jobs:
             qutip-branch: 'master'
     steps:
     - uses: actions/checkout@v3
+
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
+        folder-path: tutorials-v${{ matrix.qutip-version }}
+      continue-on-error: true
+
+    # Only stop tests for broken file in updated file.
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        check-modified-files-only: 'yes'
         folder-path: tutorials-v${{ matrix.qutip-version }}
 
     - name: Setup Mambaforge
@@ -88,13 +97,13 @@ jobs:
     - name: Check PEP8 formatting
       run: |
         pip install nbqa flake8
-        find . -name '*.ipynb' -exec nbqa flake8 {} +
+        find . -name '*.ipynb' -exec nbqa flake8 --max-line-length 88 {} +
 
     - name: Run tests
       run: |
         jupyter kernel &
         cd notebooks
-        find . -name '*.ipynb' -exec pytest --nbmake --overwrite --nbmake-timeout=500 {} +
+        find . -name '*.ipynb' -exec pytest --nbmake --overwrite --nbmake-timeout=600 {} +
         rm template.ipynb
 
     - name: Create Notebook Artifact

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -13,6 +13,7 @@ jobs:
   pytests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - qutip-version: '4'
@@ -33,6 +34,7 @@ jobs:
       with:
         use-quiet-mode: 'yes'
         check-modified-files-only: 'yes'
+        base-branch: 'main'
         folder-path: tutorials-v${{ matrix.qutip-version }}
 
     - name: Setup Mambaforge

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -99,7 +99,7 @@ jobs:
     - name: Check PEP8 formatting
       run: |
         pip install nbqa flake8
-        find . -name '*.ipynb' -exec nbqa flake8 --max-line-length 88 {} +
+        find . -name '*.ipynb' -exec nbqa flake8 --max-line-length=88 {} +
 
     - name: Run tests
       run: |


### PR DESCRIPTION
Improve some of the tests parameters to make them more forgiving.

- Set flake8's line width to 88. 88 is black's default and applying black as suggested in the README could break the flake8 test.
- Allows cells to take up to 600 sec. Some of the cells are close to the limit and sometime fails.
- Have the tests for the broken links only stop the job when a link in a modified file in broken. The check is not stable and sometime fails for links that work manually. 
- Have v4 and v5's jobs be independent. Here again a random failure in v4 should not block the tests for a new notebook in v5.