### PR TITLE
fix equation rendering

### DIFF
--- a/tutorials-v4/lectures/Lecture-2B-Single-Atom-Lasing.md
+++ b/tutorials-v4/lectures/Lecture-2B-Single-Atom-Lasing.md
@@ -55,9 +55,9 @@ In addition to the coherent dynamics the following incoherent processes are also
 
 The Lindblad master equation for the model is:
 
-$\frac{d}{dt}\rho = -i[H, \rho] + \Gamma\left(\sigma_+\rho\sigma_- - \frac{1}{2}\sigma_-\sigma_+\rho - \frac{1}{2}\rho\sigma_-\sigma_+\right)
+$$\frac{d}{dt}\rho = -i[H, \rho] + \Gamma\left(\sigma_+\rho\sigma_- - \frac{1}{2}\sigma_-\sigma_+\rho - \frac{1}{2}\rho\sigma_-\sigma_+\right)
 + \kappa (1 + n_{\rm th}) \left(a\rho a^\dagger - \frac{1}{2}a^\dagger a\rho - \frac{1}{2}\rho a^\dagger a\right)
-+ \kappa n_{\rm th} \left(a^\dagger\rho a - \frac{1}{2}a a^\dagger \rho - \frac{1}{2}\rho a a^\dagger\right)$
++ \kappa n_{\rm th} \left(a^\dagger\rho a - \frac{1}{2}a a^\dagger \rho - \frac{1}{2}\rho a a^\dagger\right)$$
 
 in units where $\hbar = 1$.
 
@@ -100,10 +100,6 @@ sx = tensor(qeye(N), sigmax())
 
 # Hamiltonian
 H = w0 * a.dag() * a + wa * sm.dag() * sm + g * (a.dag() + a) * sx
-```
-
-```python
-H
 ```
 
 ### Create a list of collapse operators that describe the dissipation

--- a/tutorials-v5/lectures/Lecture-2B-Single-Atom-Lasing.md
+++ b/tutorials-v5/lectures/Lecture-2B-Single-Atom-Lasing.md
@@ -55,9 +55,9 @@ In addition to the coherent dynamics the following incoherent processes are also
 
 The Lindblad master equation for the model is:
 
-$\frac{d}{dt}\rho = -i[H, \rho] + \Gamma\left(\sigma_+\rho\sigma_- - \frac{1}{2}\sigma_-\sigma_+\rho - \frac{1}{2}\rho\sigma_-\sigma_+\right)
+$$\frac{d}{dt}\rho = -i[H, \rho] + \Gamma\left(\sigma_+\rho\sigma_- - \frac{1}{2}\sigma_-\sigma_+\rho - \frac{1}{2}\rho\sigma_-\sigma_+\right)
 + \kappa (1 + n_{\rm th}) \left(a\rho a^\dagger - \frac{1}{2}a^\dagger a\rho - \frac{1}{2}\rho a^\dagger a\right)
-+ \kappa n_{\rm th} \left(a^\dagger\rho a - \frac{1}{2}a a^\dagger \rho - \frac{1}{2}\rho a a^\dagger\right)$
++ \kappa n_{\rm th} \left(a^\dagger\rho a - \frac{1}{2}a a^\dagger \rho - \frac{1}{2}\rho a a^\dagger\right)$$
 
 in units where $\hbar = 1$.
 
@@ -100,10 +100,6 @@ sx = tensor(qeye(N), sigmax())
 
 # Hamiltonian
 H = w0 * a.dag() * a + wa * sm.dag() * sm + g * (a.dag() + a) * sx
-```
-
-```python
-H
 ```
 
 ### Create a list of collapse operators that describe the dissipation


### PR DESCRIPTION
fix equation rendering in Lecture 2B - Single-Atom-Lasing

<img width="945" alt="image" src="https://github.com/qutip/qutip-tutorials/assets/118752873/91ce7b58-065b-4c03-ba52-ed6235ff0cff">
