### PR TITLE
Fix automated actions

### DIFF
--- a/.github/workflows/nightly_ci.yaml
+++ b/.github/workflows/nightly_ci.yaml
@@ -59,12 +59,10 @@ jobs:
         git clone -b ${{ matrix.qutip-branch }} https://github.com/qutip/qutip.git
         cd qutip
         pip install -r requirements.txt
-        python setup.py develop
+        pip install .
         cd ..
-        git clone -b master https://github.com/qutip/qutip-qip.git
-        cd qutip-qip
-        pip install -e .
-        cd ..
+        python -m pip install git+https://github.com/qutip/qutip-qip
+
         git clone -b master https://github.com/qutip/qutip-qtrl.git
         cd qutip-qtrl
         # install qutip-qtrl without deps because it requires qutip 5.0.0a1

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -27,15 +27,6 @@ jobs:
       with:
         use-quiet-mode: 'yes'
         folder-path: tutorials-v${{ matrix.qutip-version }}
-      continue-on-error: true
-
-    # Only stop tests for broken file in updated file.
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-quiet-mode: 'yes'
-        check-modified-files-only: 'yes'
-        base-branch: 'main'
-        folder-path: tutorials-v${{ matrix.qutip-version }}
 
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2
@@ -70,12 +61,10 @@ jobs:
         git clone -b ${{ matrix.qutip-branch }} https://github.com/qutip/qutip.git
         cd qutip
         pip install -r requirements.txt
-        python setup.py develop
+        pip install .
         cd ..
-        git clone -b master https://github.com/qutip/qutip-qip.git
-        cd qutip-qip
-        pip install -e .
-        cd ..
+        python -m pip install git+https://github.com/qutip/qutip-qip
+
         git clone -b master https://github.com/qutip/qutip-qtrl.git
         cd qutip-qtrl
         # install qutip-qtrl without deps because it requires qutip 5.0.0a1

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -128,10 +128,23 @@ jobs:
           cd website
 
           # Download resources from qutip.github.io repository
-          svn export https://github.com/qutip/qutip.github.io/trunk/css
-          svn export https://github.com/qutip/qutip.github.io/trunk/_includes
-          svn export https://github.com/qutip/qutip.github.io/trunk/header_source
-          svn export https://github.com/qutip/qutip.github.io/trunk/images
+          mkdir css
+          cd css
+          wget https://raw.githubusercontent.com/qutip/qutip.github.io/master/css/bootstrap.css
+          wget https://raw.githubusercontent.com/qutip/qutip.github.io/master/css/site.css
+          cd ..
+
+          mkdir _includes
+          cd _includes
+          wget https://raw.githubusercontent.com/qutip/qutip.github.io/master/_includes/footer.html
+          wget https://raw.githubusercontent.com/qutip/qutip.github.io/master/_includes/header.html
+          wget https://raw.githubusercontent.com/qutip/qutip.github.io/master/_includes/navbar.html
+          cd ..
+
+          mkdir images
+          cd images
+          wget https://raw.githubusercontent.com/qutip/qutip.github.io/master/images/favicon.ico
+          cd ..
 
           # build the website
           python create_index.py

--- a/tutorials-v4/time-evolution/012_floquet_formalism.md
+++ b/tutorials-v4/time-evolution/012_floquet_formalism.md
@@ -25,7 +25,7 @@ In the [floquet_solver notebook](011_floquet_solver.md) we introduced the two fu
 
 More information on the implementation of the Floquet Formalism in QuTiP can be found in the [documentation](https://qutip.org/docs/latest/guide/dynamics/dynamics-floquet.html).
 
-### Imports 
+### Imports
 
 ```python
 import matplotlib.pyplot as plt
@@ -40,7 +40,7 @@ from qutip import (about, expect, floquet_markov_mesolve,
 ```
 
 ### System setup
-For consistency with the documentation we consider the driven system with the following Hamiltonian: 
+For consistency with the documentation we consider the driven system with the following Hamiltonian:
 
 $$ H = - \frac{\Delta}{2} \sigma_x - \frac{\epsilon_0}{2} \sigma_z + \frac{A}{2} \sigma_x sin(\omega t) $$
 
@@ -130,13 +130,13 @@ assert np.allclose(psi_t.full(), psi_t_direct.full())
 
 ### Precomputing and reusing the Floquet modes of one period
 
-The Floquet modes have the same periodicity as the Hamiltonian: 
+The Floquet modes have the same periodicity as the Hamiltonian:
 
 $$ \phi_\alpha(t + T) = \phi_\alpha(t) $$
 
-Hence it is enough to evaluate the modes at times $t \in [0,T]$. From these modes we can extrapolate the system state $\psi(t)$ for any time $t$. 
+Hence it is enough to evaluate the modes at times $t \in [0,T]$. From these modes we can extrapolate the system state $\psi(t)$ for any time $t$.
 
-The function `floquet_modes_table` allows to calculate the Floquet modes for multiple times in the first period. 
+The function `floquet_modes_table` allows to calculate the Floquet modes for multiple times in the first period.
 
 
 ```python
@@ -172,14 +172,15 @@ plt.legend(loc="upper right")
 plt.xlabel("Time"), plt.ylabel("Occupation prob.");
 ```
 
+<!-- markdown-link-check-disable -->
 ### Floquet Markov formalism
 
-We can also solve a master equation using the Floquet formalism. A detailed derivation of the Floquet-Markov formalism used here is given in [Grifoni et al., Physics Reports 304, 299 (1998)](https://www.sciencedirect.com/science/article/abs/pii/S0370157398000222) and in the [QuTiP docs](https://qutip.org/docs/latest/guide/dynamics/dynamics-floquet.html). Note that the functionality described here is summarised in the function `fmmesolve` described in the [floquet solver notebook](011_floquet_solver.md).
+We can also solve a master equation using the Floquet formalism. A detailed derivation of the Floquet-Markov formalism used here is given in [Grifoni et al., Physics Reports 304, 299 (1998)](https://www.sciencedirect.com/science/article/pii/S0370157398000222) and in the [QuTiP docs](https://qutip.org/docs/latest/guide/dynamics/dynamics-floquet.html). Note that the functionality described here is summarised in the function `fmmesolve` described in the [floquet solver notebook](011_floquet_solver.md).
 
 The interaction with the bath is described by a noise spectrum, which does not include the temperature dependency. The temperature dependency can be passed to `fmmesolve` using the keyword `w_th` in the `args` parameter: `args[w_th]`. Hence, the definition is slightly different to the one in the Bloch-Redfield formalism. For details see the derivation of the formalism.
+<!-- markdown-link-check-enable -->
 
-
-Here we define a simple linear noise spectrum: 
+Here we define a simple linear noise spectrum:
 
 $$ S(\omega) = \frac{\gamma \cdot \omega}{4 \pi} $$
 
@@ -202,7 +203,7 @@ temp = 10.0
 args = {"w_th": temp}
 ```
 
-The Floquet Markov approach starts by calculating rates, that describe the dissipation process of the system with the given spectrum and temperature of the bath. Especially important is `Amat`, which is later used to calculate the Floquet tensor for the master equation. 
+The Floquet Markov approach starts by calculating rates, that describe the dissipation process of the system with the given spectrum and temperature of the bath. Especially important is `Amat`, which is later used to calculate the Floquet tensor for the master equation.
 
 In theory the matrix is defined as an infinite sum (see [docs](https://qutip.org/docs/latest/guide/dynamics/dynamics-floquet.html)). However, in QuTiP the sidebands need to be truncated to create a finite sum. This is done with the `kmax` argument.
 
@@ -221,7 +222,7 @@ Together with the quasienergies, the tensor for the Floquet master equation can 
 R = floquet_master_equation_tensor(Amat, f_energies)
 ```
 
-We can pass in the tensor, initial state, expectation value and expectation operator into the `floquet_markov_mesolve` function and obtain the time evolution of the system (i.e. expectation operator) using the Floquet formalism. 
+We can pass in the tensor, initial state, expectation value and expectation operator into the `floquet_markov_mesolve` function and obtain the time evolution of the system (i.e. expectation operator) using the Floquet formalism.
 
 ```python
 res_fme_manual = floquet_markov_mesolve(


### PR DESCRIPTION
Action (nightly / tests) have been failing for a while for multiple issues:
- A link in v4's tutorial work on a browser, but not with the test. Maybe the site has a bot blocker? I disabled this check.
- Removed the check for only new links. It still test all links thus failed unrelated to the PR. The non-blocking check for all links is still there.
- Install directly from github and let pip install dependencies automatically. This seems to be the most stable

With this, test passes for v4, fail for v5, but it seems related to qutip/qutip#2308, thus a true bug in the notebook, not an issues with the github actions.
For v5, it runs without cython (filelock is not a requirement), but adding it breaks some notebooks... We should investigate it later.

Also removed deprecated use of `svn` to fetch website files.

