### PR TITLE
Fix publish artifact loading.

### DIFF
--- a/.github/workflows/nightly_ci.yaml
+++ b/.github/workflows/nightly_ci.yaml
@@ -96,7 +96,7 @@ jobs:
         rm template.ipynb
 
     - name: Create Notebook Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: executed-notebooks-v${{ matrix.qutip-version }}
         path: |

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -107,7 +107,7 @@ jobs:
   publish:
     needs: pytests
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'qutip/qutip-tutorials' && github.ref == 'refs/heads/main' }}
+    # if: ${{ github.repository == 'qutip/qutip-tutorials' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@master

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -98,7 +98,7 @@ jobs:
         rm template.ipynb
 
     - name: Create Notebook Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: executed-notebooks-v${{ matrix.qutip-version }}
         path: |
@@ -110,12 +110,12 @@ jobs:
     # if: ${{ github.repository == 'qutip/qutip-tutorials' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: executed-notebooks-v4
           path: publish/tutorials-v4
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: executed-notebooks-v5
           path: publish/tutorials-v5


### PR DESCRIPTION
Publish jobs are failing to load the created artifacts, even though the artifacts are present in the job. The cause appears to have been that artifacts were uploaded with GitHub action version `v3` but downloaded with `master`.

This PR sets all the versions to `v4`.