### PR TITLE
Change default tutorial page on website

### DIFF
--- a/website/create_index.py
+++ b/website/create_index.py
@@ -110,11 +110,11 @@ with open('suffix.html', 'r') as f:
 title = 'Tutorials for QuTiP Version 4'
 version_note = 'This are the tutorials for QuTiP Version 4. You can \
          find the tutorials for QuTiP Version 5 \
-          <a href="./index-v5.html">here</a>.'
+          <a href="./index.html">here</a>.'
 
 html = generate_index_html('../tutorials-v4/', tutorial_directories, title,
                            version_note)
-with open('index.html', 'w+') as f:
+with open('index-v4.html', 'w+') as f:
     f.write(prefix)
     f.write(html)
     f.write(suffix)
@@ -123,11 +123,11 @@ with open('index.html', 'w+') as f:
 title = 'Tutorials for QuTiP Version 5'
 version_note = 'This are the tutorials for QuTiP Version 5. You can \
          find the tutorials for QuTiP Version 4 \
-          <a href="./index.html">here</a>.'
+          <a href="./index-v4.html">here</a>.'
 
 html = generate_index_html('../tutorials-v5/', tutorial_directories, title,
                            version_note)
-with open('index-v5.html', 'w+') as f:
+with open('index.html', 'w+') as f:
     f.write(prefix)
     f.write(html)
     f.write(suffix)

--- a/website/index.html.jinja
+++ b/website/index.html.jinja
@@ -14,6 +14,7 @@ useful to have a look at these IPython notebook
 <a href="https://jrjohansson.github.io/">Lectures on scientific computing with Python</a>.
 </p>
 <p> {{ version_note }} </p>
+<p> A guide for transitioning from version 4 to version 5 can be found <a href="https://colab.research.google.com/drive/18TcuHNQifYSHdGey7otK8IPDB1YbDZpW?usp=sharing">here</a>. </p>
 <p>The following are the contents of this page:</p>
 <ul>
 <li><a href="#example-notebooks">Example notebooks</a>


### PR DESCRIPTION
Switch the default for tutorial on the website for v4 to v5.
Also add a link to the migration guide on that page.

@hodgestar I expected to have to change the index references in more places, did I forget something?