### PR TITLE
QuTiPv5 Paper Notebook: smesolve

### DIFF
--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -7,20 +7,20 @@ jupyter:
       format_version: '1.3'
       jupytext_version: 1.13.8
   kernelspec:
-    display_name: qutip-tutorials-v5
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
 ---
 
 # QuTiPv5 Paper Example: Stochastic Solver - Homodyne Detection
 
-Authors: Maximilian Meyer-Mölleringhof (m.meyermoelleringhof@gmail.com)
+Authors: Maximilian Meyer-Mölleringhof (m.meyermoelleringhof@gmail.com), Neill Lambert (nwlambert@gmail.com)
 
 ## Introduction
 
 When modelling an open quantum system, stochastic noise can be used to simulate a large range of phenomena.
-In the `smesolve()` solver, noise appears because of continuous measurement.
-It allows us to generate the trajectory evolution of a quantum system conditioned on a noisy measurement record.
+In the `smesolve()` solver, noise is introduced by continuous measurement.
+This allows us to generate the trajectory evolution of a quantum system conditioned on a noisy measurement record.
 Historically speaking, such models were used by the quantum optics community to model homodyne and heterodyne detection of light emitted from a cavity.
 However, this solver is of course quite general and can thus also be applied to other problems.
 
@@ -77,7 +77,7 @@ This is compared to the regular `mesolve()` solver for the same model but withou
 rho_0 = coherent(N, np.sqrt(A))  # initial state
 times = np.arange(0, 1, 0.0025)
 num_traj = 500  # number of computed trajectories
-opt = {"dt": 0.00125, "store_measurement": True}
+opt = {"dt": 0.00125, "store_measurement": True, "map": "parallel"}
 ```
 
 ```python
@@ -127,6 +127,6 @@ about()
 
 ```python
 assert np.allclose(
-    stoc_solution.expect[0] == me_solution.expect[0]
-), "The smesolve and mesolve do not preoduce the same trajectory."
+    stoc_solution.expect[0], me_solution.expect[0], atol=1e-1
+), "smesolve and mesolve do not preoduce the same trajectory."
 ```

--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -31,15 +31,15 @@ $d \rho(t) = -i [H, \rho(t)] dt + \mathcal{D}[a] \rho (t) dt + \mathcal{H}[a] \r
 
 with the Hamiltonian
 
-$H = \Delta a^\dag a$
+$H = \Delta a^\dagger a$
 
 and the Lindblad dissipator
 
-$\mathcal{D}[a] = a \rho a^\dag - \dfrac{1}{2} a^\dag a \rho - \dfrac{1}{2} \rho a^\dag a$.
+$\mathcal{D}[a] = a \rho a^\dagger - \dfrac{1}{2} a^\dagger a \rho - \dfrac{1}{2} \rho a^\dagger a$.
 
 The stochastic part
 
-$\mathcal{H}[a]\rho = a \rho + \rho a^\dag - tr[a \rho + \rho a^\dag]$
+$\mathcal{H}[a]\rho = a \rho + \rho a^\dagger - tr[a \rho + \rho a^\dagger]$
 
 captures the conditioning of the trajectory through continious monitoring of the operator $a$.
 The term $dW(t)$ is the increment of a Wiener process that obeys $\mathbb{E}[dW] = 0$ and $\mathbb{E}[dW^2] = dt$.

--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -5,7 +5,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.13.8
+      jupytext_version: 1.16.4
   kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
@@ -27,7 +27,7 @@ However, this solver is of course quite general and can thus also be applied to 
 In this example we look at an optical cavity whose output is subject to homodyne detection.
 Such a cavity obeys the general stochastic master equation
 
-$d \rho(t) = -i [H, \rho(t)] dt + \mathcal{D}[a] \rho (t) dt + \mathcal{H}[a] \rho dW(t)$
+$d \rho(t) = -i [H, \rho(t)] dt + \mathcal{D}[a] \rho (t) dt + \mathcal{H}[a] \rho\, dW(t)$
 
 with the Hamiltonian
 
@@ -41,7 +41,7 @@ The stochastic part
 
 $\mathcal{H}[a]\rho = a \rho + \rho a^\dagger - tr[a \rho + \rho a^\dagger]$
 
-captures the conditioning of the trajectory through continious monitoring of the operator $a$.
+captures the conditioning of the trajectory through continuous monitoring of the operator $a$.
 The term $dW(t)$ is the increment of a Wiener process that obeys $\mathbb{E}[dW] = 0$ and $\mathbb{E}[dW^2] = dt$.
 
 Note that a similiar example is available in the [QuTiP user guide](https://qutip.readthedocs.io/en/qutip-5.0.x/guide/dynamics/dynamics-stochastic.html#stochastic-master-equation).
@@ -72,7 +72,7 @@ mon_op = np.sqrt(kappa) * a  # continiously monitored operators
 
 ## Solving for the Time Evolution
 
-We calculate the predicted trajectory conditioned on the continious monitoring of operator $a$.
+We calculate the predicted trajectory conditioned on the continuous monitoring of the operator $a$.
 This is compared to the regular `mesolve()` solver for the same model but without resolving conditioned trajectories.
 
 ```python
@@ -96,7 +96,7 @@ stoc_solution = smesolve(
 
 We plot the averaged homodyne current $J_x = \langle x \rangle + dW / dt$ and the average system behaviour $\langle x \rangle$ for 500 trajectories.
 This is compared with the prediction of the regular `mesolve()` solver that does not include the conditioned trajectories.
-Since the conditioned expectation values do not depend on the trajectories, we expect that this reproduces the result of the standard `me_solve`.
+Since the conditioned expectation values do not depend on the trajectories, we expect that this reproduces the result of the standard `mesolve()`.
 
 ```python
 stoc_meas_mean = np.array(stoc_solution.measurement).mean(axis=0)[0, :].real

--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -18,7 +18,7 @@ Authors: Maximilian Meyer-Mölleringhof (m.meyermoelleringhof@gmail.com)
 
 ## Introduction
 
-When modelling an open quantum system, classical noise stochastic noise can be used to simulate a large range of phenomena.
+When modelling an open quantum system, stochastic noise can be used to simulate a large range of phenomena.
 In the `smesolve()` solver, noise appears because of continuous measurement.
 It allows us to generate the trajectory evolution of a quantum system conditioned on a noisy measurement record.
 Historically speaking, such models were used by the quantum optics community to model homodyne and heterodyne detection of light emitted from a cavity.
@@ -93,7 +93,8 @@ stoc_solution = smesolve(
 ## Comparison of Results
 
 We plot the averaged homodyne current $J_x = \langle x \rangle + dW / dt$ and the average system behaviour $\langle x \rangle$ for 500 trajectories.
-This is compared with the prediction of the regular `mesolve()` solver that does not include the conditioned trajectory.
+This is compared with the prediction of the regular `mesolve()` solver that does not include the conditioned trajectories.
+Since the conditioned expectation values do not depend on the trajectories, we expect that this reproduces the result of the standard `me_solve`.
 
 ```python
 stoc_meas_mean = np.array(stoc_solution.measurement).mean(axis=0)[0, :].real
@@ -125,5 +126,7 @@ about()
 ## Testing
 
 ```python
-
+assert np.allclose(
+    stoc_solution.expect[0] == me_solution.expect[0]
+), "The smesolve and mesolve do not preoduce the same trajectory."
 ```

--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -1,0 +1,129 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: qutip-tutorials-v5
+    language: python
+    name: python3
+---
+
+# QuTiPv5 Paper Example: Stochastic Solver - Homodyne Detection
+
+Authors: Maximilian Meyer-Mölleringhof (m.meyermoelleringhof@gmail.com)
+
+## Introduction
+
+When modelling an open quantum system, classical noise stochastic noise can be used to simulate a large range of phenomena.
+In the `smesolve()` solver, noise appears because of continuous measurement.
+It allows us to generate the trajectory evolution of a quantum system conditioned on a noisy measurement record.
+Historically speaking, such models were used by the quantum optics community to model homodyne and heterodyne detection of light emitted from a cavity.
+However, this solver is of course quite general and can thus also be applied to other problems.
+
+In this example we look at an optical cavity whose output is subject to homodyne detection.
+Such a cavity obeys the general stochastic master equation
+
+$d \rho(t) = -i [H, \rho(t)] dt + \mathcal{D}[a] \rho (t) dt + \mathcal{H}[a] \rho dW(t)$
+
+with the Hamiltonian
+
+$H = \Delta a^\dag a$
+
+and the Lindblad dissipator
+
+$\mathcal{D}[a] = a \rho a^\dag - \dfrac{1}{2} a^\dag a \rho - \dfrac{1}{2} \rho a^\dag a$.
+
+The stochastic part
+
+$\mathcal{H}[a]\rho = a \rho + \rho a^\dag - tr[a \rho + \rho a^\dag]$
+
+captures the conditioning of the trajectory through continious monitoring of the operator $a$.
+The term $dW(t)$ is the increment of a Wiener process that obeys $\mathbb{E}[dW] = 0$ and $\mathbb{E}[dW^2] = dt$.
+
+```python
+import numpy as np
+from matplotlib import pyplot as plt
+from qutip import about, coherent, destroy, mesolve, smesolve
+
+%matplotlib inline
+```
+
+## Problem Parameters
+
+```python
+N = 20  # dimensions of Hilbert space
+delta = 10 * np.pi  # cavity detuning
+kappa = 1  # decay rate
+A = 4  # initial coherent state intensity
+```
+
+```python
+a = destroy(N)
+x = a + a.dag()  # operator for expectation value
+H = delta * a.dag() * a  # Hamiltonian
+mon_op = np.sqrt(kappa) * a  # continiously monitored operators
+```
+
+## Solving for the Time Evolution
+
+We calculate the predicted trajectory conditioned on the continious monitoring of operator $a$.
+This is compared to the regular `mesolve()` solver for the same model but without resolving conditioned trajectories.
+
+```python
+rho_0 = coherent(N, np.sqrt(A))  # initial state
+times = np.arange(0, 1, 0.0025)
+num_traj = 500  # number of computed trajectories
+opt = {"dt": 0.00125, "store_measurement": True}
+```
+
+```python
+me_solution = mesolve(H, rho_0, times, c_ops=[mon_op], e_ops=[x])
+```
+
+```python
+stoc_solution = smesolve(
+    H, rho_0, times, sc_ops=[mon_op], e_ops=[x], ntraj=num_traj, options=opt
+)
+```
+
+## Comparison of Results
+
+We plot the averaged homodyne current $J_x = \langle x \rangle + dW / dt$ and the average system behaviour $\langle x \rangle$ for 500 trajectories.
+This is compared with the prediction of the regular `mesolve()` solver that does not include the conditioned trajectory.
+
+```python
+stoc_meas_mean = np.array(stoc_solution.measurement).mean(axis=0)[0, :].real
+```
+
+```python
+plt.figure()
+plt.plot(times[1:], stoc_meas_mean, lw=2, label=r"$J_x$")
+plt.plot(times, stoc_solution.expect[0], label=r"$\langle x \rangle$")
+plt.plot(
+    times,
+    me_solution.expect[0],
+    "--",
+    color="gray",
+    label=r"$\langle x \rangle$ mesolve",
+)
+
+plt.legend()
+plt.xlabel(r"$t \cdot \kappa$")
+plt.show()
+```
+
+## About
+
+```python
+about()
+```
+
+## Testing
+
+```python
+
+```

--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -119,6 +119,11 @@ plt.xlabel(r"$t \cdot \kappa$")
 plt.show()
 ```
 
+## References
+
+[1] [QuTiP 5: The Quantum Toolbox in Python](https://arxiv.org/abs/2412.04705)
+
+
 ## About
 
 ```python

--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -44,6 +44,8 @@ $\mathcal{H}[a]\rho = a \rho + \rho a^\dag - tr[a \rho + \rho a^\dag]$
 captures the conditioning of the trajectory through continious monitoring of the operator $a$.
 The term $dW(t)$ is the increment of a Wiener process that obeys $\mathbb{E}[dW] = 0$ and $\mathbb{E}[dW^2] = dt$.
 
+Note that a similiar example is available in the [QuTiP user guide](https://qutip.readthedocs.io/en/qutip-5.0.x/guide/dynamics/dynamics-stochastic.html#stochastic-master-equation).
+
 ```python
 import numpy as np
 from matplotlib import pyplot as plt


### PR DESCRIPTION
Adds an example notebook for the smesolve solver mentioned in the paper for QuTiPv5.

A far as I can tell, there is only thing left to do:

- [x]  Add tests for the notebook (it's not yet clear what exactely to test)
- [x] Include references and format like [this](https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/time-evolution/013_nonmarkovian_monte_carlo.ipynb#References)