### PR TITLE
QuTiPv5 Paper Notebook: JAX examples

### DIFF
--- a/tutorials-v5/miscellaneous/v5_paper-jax.md
+++ b/tutorials-v5/miscellaneous/v5_paper-jax.md
@@ -1,0 +1,324 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+# QuTiPv5 Paper Example: QuTiP-JAX with mesolve and auto-differnetiation
+
+Authors: Maximilian Meyer-Mölleringhof (m.meyermoelleringhof@gmail.com), Neill Lambert (nwlambert@gmail.com)
+
+For many years now, GPUs have been a fundamental tool for accelerating numerical tasks.
+Today, many libraries like TensorFlow, CuPy, and JAX enable off-the-shelf methods to leverage GPUs' potential to speed up costly calculations.
+QuTiP’s flexible data layer can directly be used with these libraries and thereby drastically reduce computation time.
+Despite a big variety of frameworks, in connection to QuTiP, development has centered on the QuTiP-JAX integration due to JAX's robust auto-differentiation features and widespread adoption in machine learning.
+
+In these examples we illustrate how JAX naturally integrates into QuTiP using the QuTiP-JAX package.
+As a simple first example, we look at a one-dimensional spin chain and how we might employ `mesolve()` and JAX to solve the related master equation.
+In the second part, we focus on the auto-differentiation capabilities.
+For this we first consider the counting statistics of an open quantum system connected to an environment.
+Lastly, we look at a driven qubit system and computing the gradient of its state population in respect to the drive's frequency using `mcsolve()`.
+
+## Introduction
+
+In addition to the standrad QuTiP package, in order to use QuTiP-JAX, the JAX package needs to be installed.
+This package also comes with `jax.numpy` which mirrors all of `numpy`s functionality for seamless integration with JAX.
+
+```python
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+import qutip_jax as qj
+from diffrax import PIDController, Tsit5
+from jax import default_device, devices, grad, jacfwd, jacrev, jit
+from qutip import (CoreOptions, about, basis, destroy, lindblad_dissipator,
+                   liouvillian, mcsolve, mesolve, projection, qeye, settings,
+                   sigmam, sigmax, sigmay, sigmaz, spost, spre, sprepost,
+                   steadystate, tensor)
+
+%matplotlib inline
+```
+
+An immediate effect of importing `qutip_jax` is the availability of the data layer formats `jax` and `jax_dia`.
+They allow for dense (`jax`) and custom sparse (`jax_dia`) formats.
+
+```python
+print(qeye(3, dtype="jax").dtype.__name__)
+print(qeye(3, dtype="jaxdia").dtype.__name__)
+```
+
+In order to use the JAX data layer also within the master equation solver, there are two settings we can choose.
+First, is simply adding `method: diffrax` to the options parameter of the solver.
+Second, is to use the `qutip_jax.set_as_default()` method.
+It automatically switches all data data tyeps to JAX compatible versions and sets the default solver method to `diffrax`.
+
+```python
+qj.set_as_default()
+```
+
+To revert this setting, we can set the function parameter `revert = True`.
+
+```python
+# qj.set_as_default(revert = True)
+```
+
+## Using the GPU with JAX and Diffrax - 1D Ising Spin Chain
+
+Before diving into the example, it is worth noting here that GPU acceleration depends heavily on the type of problem.
+GPUs are good at parallelizing many small matrix-vector operations, such as integrating small systems across multiple parameters or simulating quantum circuits with repeated small matrix operations.
+For a single ODE involving large matrices, the advantages are less straightforward since ODE solvers are inherently sequential.
+However, as it is illustrated in the [QuTiPv5 paper](#References), there is a cross-over point at which using JAX is beneficial.
+
+### 1D Ising Spin Chain
+
+To illustrate the usage of QuTiP-JAX, we look at the one-dimensional spin chain with the Hamiltonian
+
+$H = \sum_{i=1}^N g_0 \sigma_z^{(n)} - \sum_{n=1}^{N-1} J_0 \sigma_x^{(n)} \sigma_x^{(n+1)}$.
+
+We hereby consider $N$ spins that share an energy splitting of $g_0$ and have a coupling strength $J_0$.
+The end of the chain connects to an environment described by a Lindbladian dissipator which we model with the collapse operator $\sigma_x^{(N-1)}$ and coupling rate $\gamma$.
+
+As part of the [QuTiPv5 paper](#References), we see an extensive study on the computation time depending on the dimensionality $N$.
+In this example we cannot replicate the performance of a supercomputer of course, so we rather focus on the correct implementation to solve the Lindablad equation for this system using JAX and `mesolve()`.
+
+```python
+# system parameters
+N = 4  # number of spins
+g0 = 1  # energy splitting
+J0 = 1.4  # coupling strength
+gamma = 0.1  # dissipation rate
+
+# simulation parameters
+tlist = jnp.linspace(0, 5, 100)
+opt = {
+    "normalize_output": False,
+    "store_states": True,
+    "method": "diffrax",
+    "stepsize_controller": PIDController(
+        rtol=settings.core["rtol"], atol=settings.core["atol"]
+    ),
+    "solver": Tsit5(),
+}
+```
+
+```python
+with CoreOptions(default_dtype="CSR"):
+    # Operators for individual qubits
+    sx_list, sy_list, sz_list = [], [], []
+    for i in range(N):
+        op_list = [qeye(2)] * N
+        op_list[i] = sigmax()
+        sx_list.append(tensor(op_list))
+        op_list[i] = sigmay()
+        sy_list.append(tensor(op_list))
+        op_list[i] = sigmaz()
+        sz_list.append(tensor(op_list))
+
+    # Hamiltonian - Energy splitting terms
+    H = 0.0
+    for i in range(N):
+        H += g0 * sz_list[i]
+
+    # Interaction terms
+    for n in range(N - 1):
+        H += -J0 * sx_list[n] * sx_list[n + 1]
+
+    # Collapse operator acting locally on single spin
+    c_ops = [gamma * sx_list[N - 1]]
+
+    # Initial state
+    state_list = [basis(2, 1)] * (N - 1)
+    state_list.append(basis(2, 0))
+    psi0 = tensor(state_list)
+
+    result = mesolve(H, psi0, tlist, c_ops, e_ops=sz_list, options=opt)
+```
+
+```python
+for i, s in enumerate(result.expect):
+    plt.plot(tlist, s, label=rf"$n = {i+1}$")
+plt.xlabel("Time")
+plt.ylabel(r"$\langle \sigma^{(n)}_z \rangle$")
+plt.legend()
+plt.show()
+```
+
+## Auto-Differentiation
+
+We have seen in the previous example how the new JAX data-layer in QuTiP enables us to run calculations on the GPU.
+On top of that, JAX adds the features of auto-differentiation.
+To compute derivatives, it is often numerical approximations (e.g., finite difference method) that need to be employed.
+Especially for higher order derivatives, these methods can turn into costly and inaccurate calculations.
+
+Auto-differenciation, on the other hand, exploits the chain rule to compute such derivatives.
+The idea is that any numerical function can be expressed by elementary analytical functions and operations.
+Consequently, using the chain rule, the derivatives of almost any higher-level function become accessible.
+
+Although there are many applications for this technique, in chapter we want to focus two examples where auto-differentiation becomes relevant.
+
+### Statistics of Excitations between Quantum System and Environment
+
+We consider an open quantum system that is in contact with an evironment via a single jump operator.
+Additionally, we have a measurement device that tracks the flow of excitations between the system and the environment.
+The probability distribution that describes the number of such exchanged excitations $n$ in a certain time $t$ is called the full counting statistics and denoted by $P_n(t)$.
+This statistics is a defining property that allows to derive many experimental observables like shot noise or current.
+
+For the example here, we can calculate this statistics by using a modified version of the density operator and Lindblad master equation.
+We introduce the *tilted* density operator $G(z,t) = \sum_n e^{zn} \rho^n (t)$ with $\rho^n(t)$ being the density operator of the system conditioned on $n$ exchanges by time $t$, so $\text{Tr}[\rho^n(t)] = P_n(t)$.
+The master equation for this operator, including the jump operator $C$, is then given as
+
+$\dot{G}(z,t) = -\dfrac{i}{\hbar} [H(t), G(z,t)] + \dfrac{1}{2} [2 e^z C \rho(t)C^\dagger - \rho C^\dagger C - C^\dagger C \rho(t)]$.
+
+We see that for $z = 0$, this master equation becomes the regular Lindblad equation and $G(0,t) = \rho(t)$.
+However, it also allows us to describe the counting statistics through its derivatives
+
+$\langle n^m \rangle (t) = \sum_n n^m \text{Tr} [\rho^n (t)] = \dfrac{d^m}{dz^m} \text{Tr} [G(z,t)]|_{z=0}$.
+
+These derivatives are precisely where the auto-differention by JAX finds its application for us.
+
+```python
+# system parameters
+ed = 1
+GammaL = 1
+GammaR = 1
+
+# simulation parameters
+options = {
+    "method": "diffrax",
+    "normalize_output": False,
+    "stepsize_controller": PIDController(rtol=1e-7, atol=1e-7),
+    "solver": Tsit5(scan_kind="bounded"),
+    "progress_bar": False,
+}
+```
+
+```python
+with default_device(devices("gpu")[0]):
+    with CoreOptions(default_dtype="jaxdia"):
+        d = destroy(2)
+        H = ed * d.dag() * d
+        c_op_L = jnp.sqrt(GammaL) * d.dag()
+        c_op_R = jnp.sqrt(GammaR) * d
+
+        L0 = (
+            liouvillian(H)
+            + lindblad_dissipator(c_op_L)
+            - 0.5 * spre(c_op_R.dag() * c_op_R)
+            - 0.5 * spost(c_op_R.dag() * c_op_R)
+        )
+        L1 = sprepost(c_op_R, c_op_R.dag())
+
+        rho0 = steadystate(L0 + L1)
+
+        def rhoz(t, z):
+            L = L0 + jnp.exp(z) * L1  # jump term
+            tlist = jnp.linspace(0, t, 50)
+            result = mesolve(L, rho0, tlist, options=options)
+            return result.final_state.tr()
+
+        # first derivative
+        drhozdz = jacrev(rhoz, argnums=1)
+        # second derivative
+        d2rhozdz = jacfwd(drhozdz, argnums=1)
+```
+
+```python
+tf = 100
+Itest = GammaL * GammaR / (GammaL + GammaR)
+shottest = Itest * (1 - 2 * GammaL * GammaR / (GammaL + GammaR) ** 2)
+ncurr = drhozdz(tf, 0.0) / tf
+nshot = (d2rhozdz(tf, 0.0) - drhozdz(tf, 0.0) ** 2) / tf
+
+print("===== RESULTS =====")
+print("Analytic current", Itest)
+print("Numerical current", ncurr)
+print("Analytical shot noise (2nd cumulant)", shottest)
+print("Numerical shot noise (2nd cumulant)", nshot)
+```
+
+### Driven One Qubit System & Frequency Optimization
+
+As a second example for auto differentiation, we consider the driven Rabi model, which is given by the time-dependent Hamiltonian
+
+$H(t) = \dfrac{\hbar \omega_0}{2} \sigma_z + \dfrac{\hbar \Omega}{2} \cos (\omega t) \sigma_x$
+
+with the energy splitting $\omega_0$, $\Omega$ as the Rabi frequency, the drive frequency $\omega$ and $\sigma_{x/z}$ are Pauli matrices.
+When we add dissipation to the system, the dynamics is given by the Lindblad master equation, which introduces collapse operator $C = \sqrt{\gamma} \sigma_-$ to describe energy relaxation.
+
+For this example, we are interested in the population of the excited state of the qubit
+
+$P_e(t) = \bra{e} \rho(t) \ket{e}$
+
+and its gradient with respect to the frequency $\omega$.
+
+We want to optimize this quantity by adjusting the drive frequency $\omega$.
+To achieve this, we compute the gradient of $P_e(t)$ in respect to $\omega$ by using JAX's auto-differentiation tools nad QuTiP's `mcsolve()`.
+
+```python
+# system parameters
+gamma = 0.1  # dissipation rate
+```
+
+```python
+# time dependent drive
+@jit
+def driving_coeff(t, omega):
+    return jnp.cos(omega * t)
+
+
+# system Hamiltonian
+def setup_system(omega):
+    H_0 = sigmaz()
+    H_1 = sigmax()
+    H = [H_0, [H_1, driving_coeff]]
+    return H
+```
+
+```python
+# simulation parameters
+psi0 = basis(2, 0)
+tlist = jnp.linspace(0.0, 10.0, 100)
+c_ops = [jnp.sqrt(gamma) * sigmam()]
+e_ops = [projection(2, 1, 1)]
+```
+
+```python
+# Objective function: returns final exc. state population
+def f(omega):
+    H = setup_system(omega)
+    arg = {"omega": omega}
+    result = mcsolve(H, psi0, tlist, c_ops, e_ops, ntraj=100, args=arg)
+    return result.expect[0][-1]
+```
+
+```python
+# Compute gradient of the exc. state population w.r.t. omega
+grad_f = grad(f)(2.0)
+```
+
+## References
+
+
+
+```python
+# TODO
+```
+
+## About
+
+```python
+about()
+```
+
+## Testing
+
+```python
+# TODO
+```

--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -7,20 +7,20 @@ jupyter:
       format_version: '1.3'
       jupytext_version: 1.13.8
   kernelspec:
-    display_name: qutip-tutorials-v5
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
 ---
 
 # QuTiPv5 Paper Example: Stochastic Solver - Homodyne Detection
 
-Authors: Maximilian Meyer-Mölleringhof (m.meyermoelleringhof@gmail.com)
+Authors: Maximilian Meyer-Mölleringhof (m.meyermoelleringhof@gmail.com), Neill Lambert (nwlambert@gmail.com)
 
 ## Introduction
 
 When modelling an open quantum system, stochastic noise can be used to simulate a large range of phenomena.
-In the `smesolve()` solver, noise appears because of continuous measurement.
-It allows us to generate the trajectory evolution of a quantum system conditioned on a noisy measurement record.
+In the `smesolve()` solver, noise is introduced by continuous measurement.
+This allows us to generate the trajectory evolution of a quantum system conditioned on a noisy measurement record.
 Historically speaking, such models were used by the quantum optics community to model homodyne and heterodyne detection of light emitted from a cavity.
 However, this solver is of course quite general and can thus also be applied to other problems.
 
@@ -77,7 +77,7 @@ This is compared to the regular `mesolve()` solver for the same model but withou
 rho_0 = coherent(N, np.sqrt(A))  # initial state
 times = np.arange(0, 1, 0.0025)
 num_traj = 500  # number of computed trajectories
-opt = {"dt": 0.00125, "store_measurement": True}
+opt = {"dt": 0.00125, "store_measurement": True, "map": "parallel"}
 ```
 
 ```python
@@ -127,6 +127,6 @@ about()
 
 ```python
 assert np.allclose(
-    stoc_solution.expect[0] == me_solution.expect[0]
-), "The smesolve and mesolve do not preoduce the same trajectory."
+    stoc_solution.expect[0], me_solution.expect[0], atol=1e-1
+), "smesolve and mesolve do not preoduce the same trajectory."
 ```

--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -31,15 +31,15 @@ $d \rho(t) = -i [H, \rho(t)] dt + \mathcal{D}[a] \rho (t) dt + \mathcal{H}[a] \r
 
 with the Hamiltonian
 
-$H = \Delta a^\dag a$
+$H = \Delta a^\dagger a$
 
 and the Lindblad dissipator
 
-$\mathcal{D}[a] = a \rho a^\dag - \dfrac{1}{2} a^\dag a \rho - \dfrac{1}{2} \rho a^\dag a$.
+$\mathcal{D}[a] = a \rho a^\dagger - \dfrac{1}{2} a^\dagger a \rho - \dfrac{1}{2} \rho a^\dagger a$.
 
 The stochastic part
 
-$\mathcal{H}[a]\rho = a \rho + \rho a^\dag - tr[a \rho + \rho a^\dag]$
+$\mathcal{H}[a]\rho = a \rho + \rho a^\dagger - tr[a \rho + \rho a^\dagger]$
 
 captures the conditioning of the trajectory through continious monitoring of the operator $a$.
 The term $dW(t)$ is the increment of a Wiener process that obeys $\mathbb{E}[dW] = 0$ and $\mathbb{E}[dW^2] = dt$.

--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -18,7 +18,7 @@ Authors: Maximilian Meyer-Mölleringhof (m.meyermoelleringhof@gmail.com)
 
 ## Introduction
 
-When modelling an open quantum system, classical noise stochastic noise can be used to simulate a large range of phenomena.
+When modelling an open quantum system, stochastic noise can be used to simulate a large range of phenomena.
 In the `smesolve()` solver, noise appears because of continuous measurement.
 It allows us to generate the trajectory evolution of a quantum system conditioned on a noisy measurement record.
 Historically speaking, such models were used by the quantum optics community to model homodyne and heterodyne detection of light emitted from a cavity.
@@ -93,7 +93,8 @@ stoc_solution = smesolve(
 ## Comparison of Results
 
 We plot the averaged homodyne current $J_x = \langle x \rangle + dW / dt$ and the average system behaviour $\langle x \rangle$ for 500 trajectories.
-This is compared with the prediction of the regular `mesolve()` solver that does not include the conditioned trajectory.
+This is compared with the prediction of the regular `mesolve()` solver that does not include the conditioned trajectories.
+Since the conditioned expectation values do not depend on the trajectories, we expect that this reproduces the result of the standard `me_solve`.
 
 ```python
 stoc_meas_mean = np.array(stoc_solution.measurement).mean(axis=0)[0, :].real
@@ -125,5 +126,7 @@ about()
 ## Testing
 
 ```python
-
+assert np.allclose(
+    stoc_solution.expect[0] == me_solution.expect[0]
+), "The smesolve and mesolve do not preoduce the same trajectory."
 ```

--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -1,0 +1,129 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: qutip-tutorials-v5
+    language: python
+    name: python3
+---
+
+# QuTiPv5 Paper Example: Stochastic Solver - Homodyne Detection
+
+Authors: Maximilian Meyer-Mölleringhof (m.meyermoelleringhof@gmail.com)
+
+## Introduction
+
+When modelling an open quantum system, classical noise stochastic noise can be used to simulate a large range of phenomena.
+In the `smesolve()` solver, noise appears because of continuous measurement.
+It allows us to generate the trajectory evolution of a quantum system conditioned on a noisy measurement record.
+Historically speaking, such models were used by the quantum optics community to model homodyne and heterodyne detection of light emitted from a cavity.
+However, this solver is of course quite general and can thus also be applied to other problems.
+
+In this example we look at an optical cavity whose output is subject to homodyne detection.
+Such a cavity obeys the general stochastic master equation
+
+$d \rho(t) = -i [H, \rho(t)] dt + \mathcal{D}[a] \rho (t) dt + \mathcal{H}[a] \rho dW(t)$
+
+with the Hamiltonian
+
+$H = \Delta a^\dag a$
+
+and the Lindblad dissipator
+
+$\mathcal{D}[a] = a \rho a^\dag - \dfrac{1}{2} a^\dag a \rho - \dfrac{1}{2} \rho a^\dag a$.
+
+The stochastic part
+
+$\mathcal{H}[a]\rho = a \rho + \rho a^\dag - tr[a \rho + \rho a^\dag]$
+
+captures the conditioning of the trajectory through continious monitoring of the operator $a$.
+The term $dW(t)$ is the increment of a Wiener process that obeys $\mathbb{E}[dW] = 0$ and $\mathbb{E}[dW^2] = dt$.
+
+```python
+import numpy as np
+from matplotlib import pyplot as plt
+from qutip import about, coherent, destroy, mesolve, smesolve
+
+%matplotlib inline
+```
+
+## Problem Parameters
+
+```python
+N = 20  # dimensions of Hilbert space
+delta = 10 * np.pi  # cavity detuning
+kappa = 1  # decay rate
+A = 4  # initial coherent state intensity
+```
+
+```python
+a = destroy(N)
+x = a + a.dag()  # operator for expectation value
+H = delta * a.dag() * a  # Hamiltonian
+mon_op = np.sqrt(kappa) * a  # continiously monitored operators
+```
+
+## Solving for the Time Evolution
+
+We calculate the predicted trajectory conditioned on the continious monitoring of operator $a$.
+This is compared to the regular `mesolve()` solver for the same model but without resolving conditioned trajectories.
+
+```python
+rho_0 = coherent(N, np.sqrt(A))  # initial state
+times = np.arange(0, 1, 0.0025)
+num_traj = 500  # number of computed trajectories
+opt = {"dt": 0.00125, "store_measurement": True}
+```
+
+```python
+me_solution = mesolve(H, rho_0, times, c_ops=[mon_op], e_ops=[x])
+```
+
+```python
+stoc_solution = smesolve(
+    H, rho_0, times, sc_ops=[mon_op], e_ops=[x], ntraj=num_traj, options=opt
+)
+```
+
+## Comparison of Results
+
+We plot the averaged homodyne current $J_x = \langle x \rangle + dW / dt$ and the average system behaviour $\langle x \rangle$ for 500 trajectories.
+This is compared with the prediction of the regular `mesolve()` solver that does not include the conditioned trajectory.
+
+```python
+stoc_meas_mean = np.array(stoc_solution.measurement).mean(axis=0)[0, :].real
+```
+
+```python
+plt.figure()
+plt.plot(times[1:], stoc_meas_mean, lw=2, label=r"$J_x$")
+plt.plot(times, stoc_solution.expect[0], label=r"$\langle x \rangle$")
+plt.plot(
+    times,
+    me_solution.expect[0],
+    "--",
+    color="gray",
+    label=r"$\langle x \rangle$ mesolve",
+)
+
+plt.legend()
+plt.xlabel(r"$t \cdot \kappa$")
+plt.show()
+```
+
+## About
+
+```python
+about()
+```
+
+## Testing
+
+```python
+
+```

--- a/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
+++ b/tutorials-v5/time-evolution/022_v5_paper-smesolve.md
@@ -44,6 +44,8 @@ $\mathcal{H}[a]\rho = a \rho + \rho a^\dag - tr[a \rho + \rho a^\dag]$
 captures the conditioning of the trajectory through continious monitoring of the operator $a$.
 The term $dW(t)$ is the increment of a Wiener process that obeys $\mathbb{E}[dW] = 0$ and $\mathbb{E}[dW^2] = dt$.
 
+Note that a similiar example is available in the [QuTiP user guide](https://qutip.readthedocs.io/en/qutip-5.0.x/guide/dynamics/dynamics-stochastic.html#stochastic-master-equation).
+
 ```python
 import numpy as np
 from matplotlib import pyplot as plt

--- a/tutorials-v5/time-evolution/025_v5_paper-nm_mcsolve.md
+++ b/tutorials-v5/time-evolution/025_v5_paper-nm_mcsolve.md
@@ -1,0 +1,358 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.8
+  kernelspec:
+    display_name: qutip-tutorials-v5
+    language: python
+    name: python3
+---
+
+# QuTiPv5 Paper Example: Monte Carlo Solver for non-Markovian Baths
+
+Authors: Maximilian Meyer-Mölleringhof (m.meyermoelleringhof@gmail.com), Neill Lambert (nwlambert@gmail.com)
+
+## Introduction
+
+When a quantum system experiences non-Markovian effects, it can no longer be described using the standard Lindblad formalism.
+To compute the time evolution of the density matrix, we can however use time-convolutionless (TCL) projection operators that lead to a differential equation in time-local form:
+
+$\dot{\rho} (t) = - \dfrac{i}{\hbar} [H(t), \rho(t)] + \sum_n \gamma_n(t) \mathcal{D}_n(t) [\rho(t)]$
+
+with
+
+$\mathcal{D}_n[\rho(t)] = A_n \rho(t) A^\dagger_n - \dfrac{1}{2} [A^\dagger_n A_n \rho(t) + \rho(t) A_n^\dagger A_n]$.
+
+These equations include the system Hamiltonian $H(t)$ and jump operators $A_n$.
+Contrary to a Lindblad equation, the coupling rates $\gamma_n(t)$ may be negative here.
+
+In QuTiPv5, the non-Markovian Monte Carlo solver is introduced.
+It enables the mapping of the general master equation given above, to a Lindblad equation on the same Hilbert space.
+This is achieved by the introduction of so called "influence martingale" which act as trajectory weighting [\[1, 2, 3\]](#References):
+
+$\mu (t) = \exp \left[ \alpha \int_0^t s(\tau) d \tau \right] \Pi_k \dfrac{\gamma_{n_k} (t_k)}{\Gamma_{n_k} (t_k)}$.
+
+Here, the product runs over all jump operators on the trajectory with jump channels $n_k$ and jump times $t_k < t$.
+
+The jump operators are required to fulfill the completeness relation $\sum_n A_n^\dagger A_n = \alpha \mathbb{1}$ for $\alpha > 0$.
+This condition is automatically taken care off by QuTiP's `nm_mcsolve()` function.
+
+To finally arrive at the Lindblad form, the shift function
+
+$s(t) = 2 | \min \{ 0, \gamma_1(t), \gamma_2(t), ... \} |$,
+
+such that the shifted rates $\Gamma_n (t) = \gamma_n(t) + s(t)$ non-negative.
+Using the regular MCWF method, we obtain the completely positive Lindblad equation
+
+$\dot{\rho}'(t) = - \dfrac{i}{\hbar} [ H(t), \rho'(t) ] + \sum_n \Gamma(t) \mathcal{D}_n[\rho'(t)]$,
+
+so that $\rho'(t) = \mathcal{E} \{\ket{\psi(t)} \bra{\psi(t)}\}$ for the generated trajecotries $\ket{\psi (t)}$.
+
+
+
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import qutip as qt
+from qutip import (about, basis, brmesolve, expect, lindblad_dissipator,
+                   liouvillian, mesolve, nm_mcsolve, qeye, sigmam, sigmap,
+                   sigmax, sigmay, sigmaz)
+from scipy.interpolate import CubicSpline
+from scipy.optimize import root_scalar
+```
+
+## Damped Jaynes-Cumming Model
+
+To illustrate the application of `nm_mcsolve()`, we want to look at the damped Jaynes-Cumming model.
+It describes a two-level atom coupled to a damped cavity mode.
+Such a model can be accurately model as a two-level system coupled to an environment with the power spectrum [\[4\]](#References):
+
+$S(\omega) = \dfrac{\lambda \Gamma^2}{(\omega_0 - \Delta - \omega)^2 + \Gamma^2}$,
+
+where $\lambda$ is the atom-cavity coupling strength, $\omega_0$ is the transition frequency of the atom, $\Delta$ the detuning of the cavity and $\Gamma$ the spectral width.
+At zero temperature and after performing the rotating wave approximation, the dynamics of the two-level atom can be described by the master equation
+
+$\dot{\rho}(t) = \dfrac{A(t)}{2i\hbar} [ \sigma_+ \sigma_-, \rho(t) ] + \gamma (t) \mathcal{D}_- [\rho (t)]$,
+
+with the state $\rho(t)$ in the interaction picture, the the ladder operators $\sigma_\pm$, the dissipator $\mathcal{D}_-$ for the Lindblad operator $\sigma_-$, and lastly $\gamma (t)$ and $A(t)$ being the real and imaginary parts of
+
+$\gamma(t) + i A(t) = \dfrac{2 \lambda \Gamma \sinh (\delta t / 2)}{\delta \cosh (\delta t / 2) + (\Gamma - i \Delta) \sinh (\delta t/2)}$,
+
+with $\delta = [(\Gamma - i \Delta)^2 - 2 \lambda \Gamma]^{1/2}$.
+
+```python
+H = sigmap() * sigmam() / 2
+initial_state = (basis(2, 0) + basis(2, 1)).unit()
+tlist = np.linspace(0, 5, 500)
+```
+
+```python
+# Constants
+gamma0 = 1
+lamb = 0.3 * gamma0
+Delta = 8 * lamb
+
+# Derived Quantities
+delta = np.sqrt((lamb - 1j * Delta) ** 2 - 2 * gamma0 * lamb)
+deltaR = np.real(delta)
+deltaI = np.imag(delta)
+deltaSq = deltaR**2 + deltaI**2
+```
+
+```python
+# calculate gamma and A
+def prefac(t):
+    return (
+        2
+        * gamma0
+        * lamb
+        / (
+            (lamb**2 + Delta**2 - deltaSq) * np.cos(deltaI * t)
+            - (lamb**2 + Delta**2 + deltaSq) * np.cosh(deltaR * t)
+            - 2 * (Delta * deltaR + lamb * deltaI) * np.sin(deltaI * t)
+            + 2 * (Delta * deltaI - lamb * deltaR) * np.sinh(deltaR * t)
+        )
+    )
+
+
+def cgamma(t):
+    return prefac(t) * (
+        lamb * np.cos(deltaI * t)
+        - lamb * np.cosh(deltaR * t)
+        - deltaI * np.sin(deltaI * t)
+        - deltaR * np.sinh(deltaR * t)
+    )
+
+
+def cA(t):
+    return prefac(t) * (
+        Delta * np.cos(deltaI * t)
+        - Delta * np.cosh(deltaR * t)
+        - deltaR * np.sin(deltaI * t)
+        + deltaI * np.sinh(deltaR * t)
+    )
+```
+
+```python
+_gamma = np.zeros_like(tlist)
+_A = np.zeros_like(tlist)
+for i in range(len(tlist)):
+    _gamma[i] = cgamma(tlist[i])
+    _A[i] = cA(tlist[i])
+
+gamma = CubicSpline(tlist, np.complex128(_gamma))
+A = CubicSpline(tlist, np.complex128(_A))
+```
+
+```python
+unitary_gen = liouvillian(H)
+dissipator = lindblad_dissipator(sigmam())
+me_sol = mesolve([[unitary_gen, A], [dissipator, gamma]], initial_state, tlist)
+```
+
+```python
+mc_sol = nm_mcsolve(
+    [[H, A]],
+    initial_state,
+    tlist,
+    ops_and_rates=[(sigmam(), gamma)],
+    ntraj=1_000,
+    options={"map": "parallel"},
+    seeds=0,
+)
+```
+
+## Comparison to other methods
+
+We want to compare this computation with the HEOM and the Bloch-Refield solver.
+For these methods we directly apply a spin-boson model and the free reservoir auto-correlation function
+
+$C(t) = \dfrac{\lambda \Gamma}{2} e^{-i (\omega - \Delta) t - \lambda |t|}$
+
+as well as the same power specture as we used above.
+We use the Hamiltonian $H = \omega_0 \sigma_+ \sigma_-$ in the Schrödinger picture and the coupling operator $Q = \sigma_+ + \sigma_-$.
+Here, we chose $\omega_0 \gg \Delta$ to ensure validity of the rotating wave approximation.
+
+```python
+omega_c = 100
+omega_0 = omega_c + Delta
+
+H = omega_0 * qt.sigmap() * qt.sigmam()
+Q = qt.sigmap() + qt.sigmam()
+
+
+def power_spectrum(w):
+    return gamma0 * lamb**2 / ((omega_c - w) ** 2 + lamb**2)
+```
+
+Firstly, the HEOM solver can directly be applied after separating the auto-correlation function into its real and imaginary parts:
+
+```python
+ck_real = [gamma0 * lamb / 4] * 2
+vk_real = [lamb - 1j * omega_c, lamb + 1j * omega_c]
+ck_imag = np.array([1j, -1j]) * gamma0 * lamb / 4
+vk_imag = vk_real
+```
+
+```python
+heom_bath = qt.heom.BosonicBath(Q, ck_real, vk_real, ck_imag, vk_imag)
+heom_sol = qt.heom.heomsolve(H, heom_bath, 10, qt.ket2dm(initial_state), tlist)
+```
+
+And secondly, for the Bloch-Redfield solver we can directly use the power spectrum as input:
+
+```python
+br_sol = brmesolve(H, initial_state, tlist, a_ops=[(sigmax(), power_spectrum)])
+```
+
+Finally, in order to compare these results with the `nm_mesolve()` method, we transform them to the interaction picture:
+
+```python
+Us = [(-1j * H * t).expm() for t in tlist]
+heom_states = [U * s * U.dag() for (U, s) in zip(Us, heom_sol.states)]
+br_states = [U * s * U.dag() for (U, s) in zip(Us, br_sol.states)]
+```
+
+### Plotting the Time Evolution
+
+We choose to plot three comparisons to highlight the different solvers' computational results.
+In all plots, the gray areas show when $\gamma(t)$ is negative.
+
+```python
+root1 = root_scalar(lambda t: cgamma(t), method="bisect", bracket=(1, 2)).root
+root2 = root_scalar(lambda t: cgamma(t), method="bisect", bracket=(2, 3)).root
+root3 = root_scalar(lambda t: cgamma(t), method="bisect", bracket=(3, 4)).root
+root4 = root_scalar(lambda t: cgamma(t), method="bisect", bracket=(4, 5)).root
+```
+
+```python
+projector = (sigmaz() + qeye(2)) / 2
+
+rho11_me = expect(projector, me_sol.states)
+rho11_mc = expect(projector, mc_sol.states[::10])
+rho11_br = expect(projector, br_sol.states)
+rho11_heom = expect(projector, heom_states)
+
+plt.plot(tlist, rho11_me, "-", color="orange", label="mesolve")
+plt.plot(
+    tlist[::10],
+    rho11_mc,
+    "x",
+    color="blue",
+    label="nm_mcsolve",
+)
+plt.plot(tlist, rho11_br, "-.", color="gray", label="brmesolve")
+plt.plot(tlist, rho11_heom, "--", color="green", label="heomsolve")
+
+plt.xlabel(r"$t\, /\, \lambda^{-1}$")
+plt.xlim((-0.2, 5.2))
+plt.xticks([0, 2.5, 5], labels=["0", "2.5", "5"])
+plt.title(r"$\rho_{11}$")
+plt.ylim((0.4376, 0.5024))
+plt.yticks([0.44, 0.46, 0.48, 0.5], labels=["0.44", "0.46", "0.48", "0.50"])
+
+plt.axvspan(root1, root2, color="gray", alpha=0.08, zorder=0)
+plt.axvspan(root3, root4, color="gray", alpha=0.08, zorder=0)
+
+plt.legend()
+plt.show()
+```
+
+```python
+me_x = expect(sigmax(), me_sol.states)
+mc_x = expect(sigmax(), mc_sol.states[::10])
+heom_x = expect(sigmax(), heom_states)
+br_x = expect(sigmax(), br_states)
+
+me_y = expect(sigmay(), me_sol.states)
+mc_y = expect(sigmay(), mc_sol.states[::10])
+heom_y = expect(sigmay(), heom_states)
+br_y = expect(sigmay(), br_states)
+```
+
+```python
+# We smooth the HEOM result because it oscillates quickly and gets hard to see
+heom_plot = heom_x * heom_x + heom_y * heom_y
+heom_plot = np.convolve(heom_plot, np.array([1 / 11] * 11), mode="valid")
+heom_tlist = tlist[5:-5]
+```
+
+```python
+rho01_me = me_x * me_x + me_y * me_y
+rho01_mc = mc_x * mc_x + mc_y * mc_y
+rho01_br = br_x * br_x + br_y * br_y
+
+plt.plot(tlist, rho01_me, "-", color="orange", label=r"mesolve")
+plt.plot(tlist[::10], rho01_mc, "x", color="blue", label=r"nm_mcsolve")
+plt.plot(heom_tlist, heom_plot, "--", color="green", label=r"heomsolve")
+plt.plot(tlist, rho01_br, "-.", color="gray", label=r"brmesolve")
+
+plt.xlabel(r"$t\, /\, \lambda^{-1}$")
+plt.xlim((-0.2, 5.2))
+plt.xticks([0, 2.5, 5], labels=["0", "2.5", "5"])
+plt.title(r"$| \rho_{01} |^2$")
+plt.ylim((0.8752, 1.0048))
+plt.yticks(
+    [0.88, 0.9, 0.92, 0.94, 0.96, 0.98, 1],
+    labels=["0.88", "0.90", "0.92", "0.94", "0.96", "0.98", "1"],
+)
+
+plt.axvspan(root1, root2, color="gray", alpha=0.08, zorder=0)
+plt.axvspan(root3, root4, color="gray", alpha=0.08, zorder=0)
+
+plt.legend()
+plt.show()
+```
+
+```python
+plt.plot(tlist, np.zeros_like(tlist), "-", color="orange", label=r"Zero")
+plt.plot(
+    tlist[::10],
+    1000 * (mc_sol.trace[::10] - 1),
+    "x",
+    color="blue",
+    label=r"nm_mcsolve",
+)
+
+plt.xlabel(r"$t\, /\, \lambda^{-1}$")
+plt.xlim((-0.2, 5.2))
+plt.xticks([0, 2.5, 5], labels=["0", "2.5", "5"])
+plt.title(r"$(\mu - 1)\, /\, 10^{-3}$")
+plt.ylim((-5.8, 15.8))
+plt.yticks([-5, 0, 5, 10, 15])
+
+plt.axvspan(root1, root2, color="gray", alpha=0.08, zorder=0)
+plt.axvspan(root3, root4, color="gray", alpha=0.08, zorder=0)
+
+plt.legend()
+plt.show()
+```
+
+## References
+
+\[1\] [Donvil and Muratore-Ginanneschi. Nat Commun (2022).](https://www.nature.com/articles/s41467-022-31533-8)
+
+\[2\] [Donvil and Muratore-Ginanneschi. New J. Phys. (2023).](https://dx.doi.org/10.1088/1367-2630/acd4dc)
+
+\[3\] [Donvil and Muratore-Ginanneschi. *Open Systems & Information Dynamics*.](https://www.worldscientific.com/worldscinet/osid)
+
+\[4\] [Breuer and Petruccione *The Theory of Open Quantum Systems*.](https://doi.org/10.1093/acprof:oso/9780199213900.001.0001)
+
+
+
+## About
+
+```python
+about()
+```
+
+## Testing
+
+```python
+# TODO
+```


### PR DESCRIPTION
Adds the JAX code examples of the paper as notebook. Inlcudes the standard mesolve as well as count stat. & gradient calculation all in one notebook.

TODO:

- [ ] References
- [ ] Testing
- [ ] Some nicer plots (I am open for ideas)