### PR TITLE
Change file name of `cpo-GRAPE-cnot`

### DIFF
--- a/tutorials-v5/optimal-control/08-cpo-GRAPE-cnot.md
+++ b/tutorials-v5/optimal-control/08-cpo-GRAPE-cnot.md
@@ -12,7 +12,7 @@ jupyter:
     name: python3
 ---
 
-### GRAPE calculation of control fields for cnot implementation
+# GRAPE calculation of control fields for cnot implementation
 
 [This is an updated implementation based on the deprecated notebook of GRAPE CNOT implementation by Robert Johansson](https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/control-grape-cnot.ipynb)
 


### PR DESCRIPTION
Changed file name of `cpo-GRAPE-cnot` from `01` to `08` to appear at the end rather the start of the `tutorials`.