### PR TITLE
Change link check config in `notebook_ci.yaml` 

### DIFF
--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -29,7 +29,7 @@ jobs:
         folder-path: tutorials-v${{ matrix.qutip-version }}
         #use config file to define 403 and 405 errors as valid links
         #(APS blocks this link check)
-        config-file: mlc_config.json
+        config-file: mlc_external_config.json
 
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v3
@@ -107,6 +107,15 @@ jobs:
         path: |
           notebooks/*.ipynb
           notebooks/**/*.ipynb
+   
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        folder-path: tutorials-v${{ matrix.qutip-version }}
+        #use config file to define 403 and 405 errors as valid links
+        #(APS blocks this link check)
+        config-file: mlc_config.json
+
   publish:
     needs: pytests
     runs-on: ubuntu-latest

--- a/mlc_external_config.json
+++ b/mlc_external_config.json
@@ -1,0 +1,14 @@
+{
+    "projectBaseUrl":"${workspaceFolder}",
+    "timeout": "20s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [200, 206, 403, 405],
+    "ignorePatterns": [
+    {
+      "pattern": "^(/|\\.\\/|\\.\\./)"  
+    }
+    ]
+}
+  


### PR DESCRIPTION
Fixes #129 

Change link check process during build in `notebook_ci.yaml` to first check external links and at the end check all the links.