### PR TITLE
Pin qutip-qip version to 0.4

### DIFF
--- a/.github/workflows/nightly_ci.yaml
+++ b/.github/workflows/nightly_ci.yaml
@@ -20,7 +20,7 @@ jobs:
             qip-branch: 'qutip-qip-0.4.X'
           - qutip-version: '5'
             qutip-branch: 'master'
-            qip-branch: 'master'
+            qip-branch: 'qutip-qip-0.4.X'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/nightly_ci.yaml
+++ b/.github/workflows/nightly_ci.yaml
@@ -17,10 +17,12 @@ jobs:
         include:
           - qutip-version: '4'
             qutip-branch: 'qutip-4.7.X'
-            qip-branch: 'qutip-qip-0.4.X'
+            qutip-install-spec: 'qutip==4.7.*'
+            qip-install-spec: 'qutip-qip==0.4.*'
           - qutip-version: '5'
             qutip-branch: 'master'
-            qip-branch: 'qutip-qip-0.4.X'
+            qutip-install-spec: 'qutip'
+            qip-install-spec: 'qutip-qip'
 
     steps:
     - uses: actions/checkout@v4
@@ -57,16 +59,12 @@ jobs:
         git clone -b ${{ matrix.qutip-branch }} https://github.com/qutip/qutip.git
         cd qutip
         pip install -r requirements.txt
-        pip install .
         cd ..
-        python -m pip install git+https://github.com/qutip/qutip-qip@${{ matrix.qip-branch }}
+        python -m pip install "${{ matrix.qutip-install-spec }}"
+        python -m pip install "${{ matrix.qip-install-spec }}"
         python -m pip install --no-deps git+https://github.com/qutip/qutip-jax
+        python -m pip install --no-deps git+https://github.com/qutip/qutip-qtrl
         python -m pip install --no-deps git+https://github.com/qutip/qutip-qoc
-
-        git clone -b master https://github.com/qutip/qutip-qtrl.git
-        cd qutip-qtrl
-        # install qutip-qtrl without deps because it requires qutip 5.0.0a1
-        pip install --no-deps -e .
 
     - name: Install ffmpeg & LaTeX
       run: |

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -21,7 +21,7 @@ jobs:
             qip-branch: 'qutip-qip-0.4.X'
           - qutip-version: '5'
             qutip-branch: 'master'
-            qip-branch: 'master'
+            qip-branch: 'qutip-qip-0.4.X'
     steps:
     - uses: actions/checkout@v4
 

--- a/tutorials-v5/pulse-level-circuit-simulation/qip-processor-DJ-algorithm.md
+++ b/tutorials-v5/pulse-level-circuit-simulation/qip-processor-DJ-algorithm.md
@@ -37,7 +37,7 @@ from qutip_qip.device import (LinearSpinChain, OptPulseProcessor, SCQubits,
 ```
 
 ```python
-qc = QubitCircuit(num_qubits=3)
+qc = QubitCircuit(3)
 qc.add_gate("X", targets=2)
 qc.add_gate("SNOT", targets=0)
 qc.add_gate("SNOT", targets=1)


### PR DESCRIPTION
The new development version of qutip-qip introduced new ways to define Gate. We need to update the notebooks. However, before the new qutip-qip is released, all notebooks should still be built on the old version.

This PR pins the qutip-qip notebook env to qutip-0.4.*. This version should be bumped up for tutorial v5 once qutip-qip-0.5 is released and notebooks are updated.