### PR TITLE
Fix QuTiP master API compatibility in notebooks

### DIFF
--- a/tutorials-v5/lectures/Lecture-0-Introduction-to-QuTiP.md
+++ b/tutorials-v5/lectures/Lecture-0-Introduction-to-QuTiP.md
@@ -513,7 +513,7 @@ tlist = np.linspace(0, 50, 100)
 
 # request that the solver return the expectation value
 # of the photon number state operator a.dag() * a
-result = mesolve(H, rho0, tlist, c_ops, [a.dag() * a],
+result = mesolve(H, rho0, tlist, c_ops, e_ops=[a.dag() * a],
                  options={"store_states": True})
 ```
 

--- a/tutorials-v5/lectures/Lecture-8-Adiabatic-quantum-computing.md
+++ b/tutorials-v5/lectures/Lecture-8-Adiabatic-quantum-computing.md
@@ -157,7 +157,7 @@ def process_rho(tau, psi):
 ```python
 # Evolve the system, request the solver to call process_rho at each time step.
 
-mesolve(h_t, psi0, taulist, [], process_rho, args)
+mesolve(h_t, psi0, taulist, [], e_ops=process_rho, args=args)
 ```
 
 ## Visualize the results

--- a/tutorials-v5/miscellaneous/excitation-number-restricted-states-jc-chain.md
+++ b/tutorials-v5/miscellaneous/excitation-number-restricted-states-jc-chain.md
@@ -126,7 +126,7 @@ def solve(d, psi0):
     times = np.linspace(0, 250, 1000)
     L = liouvillian(H, c_ops)
     opt = {"nsteps": 5000, "store_states": True}
-    result = mesolve(H, psi0, times, c_ops, e_ops, options=opt)
+    result = mesolve(H, psi0, times, c_ops, e_ops=e_ops, options=opt)
     return result, H, L
 ```
 

--- a/tutorials-v5/pulse-level-circuit-simulation/qip-randomized-benchmarking.md
+++ b/tutorials-v5/pulse-level-circuit-simulation/qip-randomized-benchmarking.md
@@ -22,7 +22,7 @@ Note: This example is quite computationally expensivem, hence for the full simul
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from qutip import (Qobj, SolverOptions, about, basis, fock_dm, qeye,
+from qutip import (Qobj, about, basis, fock_dm, qeye,
                    sigmax, sigmay, sigmaz, tensor)
 from qutip_qip.circuit import QubitCircuit
 from qutip_qip.compiler import GateCompiler, Instruction
@@ -256,7 +256,7 @@ def single_crosstalk_simulation(num_gates):
          Qobj([[init_fid, 0], [0, 0.025]])]
     )
     # increase the maximal allowed steps
-    options = SolverOptions(nsteps=10000)
+    options = {"nsteps": 10000}
     e_ops = [tensor([qeye(2), fock_dm(2)])]  # observable
 
     # compute results of the run using a solver of choice

--- a/tutorials-v5/template.md
+++ b/tutorials-v5/template.md
@@ -66,7 +66,7 @@ also use comments in the code section to separate the operations you perform.
 # simulate the unitary dynamics
 H = sigmaz()
 times = np.linspace(0, 10, 100)
-result = sesolve(H, psi, times, [sigmay()])
+result = sesolve(H, psi, times, e_ops=[sigmay()])
 
 # plot the expectation value
 plt.plot(times, result.expect[0])

--- a/tutorials-v5/time-evolution/002_larmor-precession.md
+++ b/tutorials-v5/time-evolution/002_larmor-precession.md
@@ -61,7 +61,7 @@ Here, we are for example interested in the time evolution of the expectation val
 # simulate the unitary dynamics
 H = sigmaz()
 times = np.linspace(0, 10, 100)
-result = sesolve(H, psi, times, [sigmay()])
+result = sesolve(H, psi, times, e_ops=[sigmay()])
 ```
 
 `result.expect` holds the expecation values for the times that we passed to `sesolve`. `result.expect` is a two dimensional array, where the first dimension refers to the different expectation operators that we passed to `sesolve` before. 
@@ -77,7 +77,7 @@ plt.show()
 Above we gave `sigmay()` as an operator to `sesolve` to directly calculate it's expectation value. If we pass an empty list at this argument to `sesolve` it will return the quantum state of the system for each time step in `times`. We can access the states by `result.states` and use them for example to plot the states on the Bloch sphere to see the precession. If the solver take a long time to run, it is also a good idea to return the states, so you can calculate different things, without specifying before the calculation.
 
 ```python
-res = sesolve(H, psi, times, [])
+res = sesolve(H, psi, times, e_ops=[])
 b = Bloch()
 b.add_states(res.states[1:30])
 b.show()
@@ -108,8 +108,8 @@ H_per = QobjEvo([[sigmaz(), periodic]], tlist=times)
 We can now continue as in the previous section and use `sesolve` to solve the Schrödinger equation.
 
 ```python
-result_lin = sesolve(H_lin, psi, times, [sigmay()])
-result_per = sesolve(H_per, psi, times, [sigmay()])
+result_lin = sesolve(H_lin, psi, times, e_ops=[sigmay()])
+result_per = sesolve(H_per, psi, times, e_ops=[sigmay()])
 
 
 # Plot <sigma_y> for linear increasing field strength

--- a/tutorials-v5/time-evolution/003_qubit-dynamics.md
+++ b/tutorials-v5/time-evolution/003_qubit-dynamics.md
@@ -68,7 +68,7 @@ tlist = np.linspace(0, 5, 100)
 We pass these definition to the `qutip.mesolve` function. The collapse operators need to be passed in a list (even if there is only one collapse operator). As the fifth argument we pass a list of operators, for which the solver will return the expectation value at the given times in `tlist`. In this example we want to obtain the expectation value for $\sigma_z$.
 
 ```python
-res = mesolve(H, psi0, tlist, c_ops, [sigmaz()])
+res = mesolve(H, psi0, tlist, c_ops, e_ops=[sigmaz()])
 ```
 
 For this particular Hamiltonian and dissipation process we can derive the analytical solution for the expectation value of $\sigma_z$.
@@ -108,7 +108,7 @@ H = delta * (np.cos(theta) * sigmaz() + np.sin(theta) * sigmax())
 
 # Obtain Time Evolution
 tlist = np.linspace(0, 5, 1000)
-result = mesolve(H, psi0, tlist, [], [sigmax(), sigmay(), sigmaz()])
+result = mesolve(H, psi0, tlist, [], e_ops=[sigmax(), sigmay(), sigmaz()])
 ```
 
 We can visualise the state on the Bloch sphere by using the `qutip.Bloch` class. We can add points to the Bloch sphere and also vectors representing states.
@@ -142,7 +142,7 @@ gamma_phase = 0.5
 c_ops = [np.sqrt(gamma_phase) * sigmaz()]
 
 # solve dynamics
-result = mesolve(H, psi0, tlist, c_ops, [sigmax(), sigmay(), sigmaz()])
+result = mesolve(H, psi0, tlist, c_ops, e_ops=[sigmax(), sigmay(), sigmaz()])
 exp_sx_dephase, exp_sy_dephase, exp_sz_dephase = result.expect
 exp_sx_dephase, exp_sy_dephase, exp_sz_dephase = (
     np.array(exp_sx_dephase),
@@ -172,7 +172,7 @@ gamma_relax = 0.5
 c_ops = [np.sqrt(gamma_relax) * sigmam()]
 
 # solve dynamics
-result = mesolve(H, psi0, tlist, c_ops, [sigmax(), sigmay(), sigmaz()])
+result = mesolve(H, psi0, tlist, c_ops, e_ops=[sigmax(), sigmay(), sigmaz()])
 exp_sx_relax, exp_sy_relax, exp_sz_relax = result.expect
 
 # Create Bloch sphere plot

--- a/tutorials-v5/time-evolution/004_rabi-oscillations.md
+++ b/tutorials-v5/time-evolution/004_rabi-oscillations.md
@@ -124,7 +124,7 @@ c_op_list.append(np.sqrt(rate) * sm)
 Here we evolve the system with the Lindblad master equation solver `qutip.mesolve`, and we request that the expectation values of the operators $a^\dagger a$ and $\sigma_+\sigma_-$ are returned by the solver by passing the list `[a.dag()*a, sm.dag()*sm]` as the fifth argument to the solver.
 
 ```python
-output = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a, sm.dag() * sm])
+output = mesolve(H, psi0, tlist, c_op_list, e_ops=[a.dag() * a, sm.dag() * sm])
 ```
 
 ### Visualize the results
@@ -158,7 +158,7 @@ rate = gamma
 c_op_list.append(np.sqrt(rate) * sm)
 
 # evolve system
-output_temp = mesolve(H, psi0, tlist, c_op_list, [a.dag() * a, sm.dag() * sm])
+output_temp = mesolve(H, psi0, tlist, c_op_list, e_ops=[a.dag() * a, sm.dag() * sm])
 
 # plot
 fig, ax = plt.subplots(figsize=(8, 5))
@@ -184,7 +184,7 @@ atom_and_cavity = np.array(output.expect[0]) + np.array(output.expect[1])
 assert np.all(np.diff(atom_and_cavity) <= 0.0)
 
 # frequency for analytical solution (with RWA)
-output_no_cops = mesolve(H, psi0, tlist, [], [a.dag() * a, sm.dag() * sm])
+output_no_cops = mesolve(H, psi0, tlist, [], e_ops=[a.dag() * a, sm.dag() * sm])
 freq = 1 / 4 * np.sqrt(g**2 * (N + 1))
 assert np.allclose(output_no_cops.expect[1],
                    (np.cos(tlist * freq)) ** 2, atol=10**-3)

--- a/tutorials-v5/time-evolution/005_spin-chain.md
+++ b/tutorials-v5/time-evolution/005_spin-chain.md
@@ -92,7 +92,7 @@ We can simulate the system using the `qutip.mesolve` function. Here, we don't pa
 
 ```python
 times = np.linspace(0, 100, 200)
-result = mesolve(H, psi0, times, [], [])
+result = mesolve(H, psi0, times, [], e_ops=[])
 # Convert states to density matrices
 states = [s * s.dag() for s in result.states]
 ```
@@ -127,7 +127,7 @@ gamma = 0.02 * np.ones(N)
 c_ops = [np.sqrt(gamma[i]) * sz_list[i] for i in range(N)]
 
 # evolution
-result = result = mesolve(H, psi0, times, c_ops, [])
+result = result = mesolve(H, psi0, times, c_ops, e_ops=[])
 
 # Expectation value
 exp_sz_dephase = expect(sz_list, result.states)

--- a/tutorials-v5/time-evolution/006_photon_birth_death.md
+++ b/tutorials-v5/time-evolution/006_photon_birth_death.md
@@ -86,9 +86,9 @@ tlist = np.linspace(0, 0.8, 100)
 
 # Solve using MCSolve for different ntraj
 for n in ntraj:
-    result = mcsolve(H, psi0, tlist, c_ops, [a.dag() * a], ntraj=n)
+  result = mcsolve(H, psi0, tlist, c_ops, e_ops=[a.dag() * a], ntraj=n)
     mc.append(result)
-me = mesolve(H, psi0, tlist, c_ops, [a.dag() * a])
+me = mesolve(H, psi0, tlist, c_ops, e_ops=[a.dag() * a])
 ```
 
 ## Reproduce plot from article

--- a/tutorials-v5/time-evolution/006_photon_birth_death.md
+++ b/tutorials-v5/time-evolution/006_photon_birth_death.md
@@ -86,7 +86,7 @@ tlist = np.linspace(0, 0.8, 100)
 
 # Solve using MCSolve for different ntraj
 for n in ntraj:
-  result = mcsolve(H, psi0, tlist, c_ops, e_ops=[a.dag() * a], ntraj=n)
+    result = mcsolve(H, psi0, tlist, c_ops, e_ops=[a.dag() * a], ntraj=n)
     mc.append(result)
 me = mesolve(H, psi0, tlist, c_ops, e_ops=[a.dag() * a])
 ```

--- a/tutorials-v5/time-evolution/007_brmesolve_tls.md
+++ b/tutorials-v5/time-evolution/007_brmesolve_tls.md
@@ -69,7 +69,7 @@ psi0 = (2 * basis(2, 0) + basis(2, 1)).unit()
 # Setup the master equation solver
 c_ops = [np.sqrt(gamma) * sigmam()]
 e_ops = [sigmax(), sigmay(), sigmaz()]
-result_me = mesolve(H, psi0, times, c_ops, e_ops)
+result_me = mesolve(H, psi0, times, c_ops, e_ops=e_ops)
 ```
 
 For the `qutip.brmesolve` function we have to give the interaction of the system with the bath as a hermitian operator together with a noise power spectrum, which defines the strength of the interaction per frequency. Here we define a constant interaction whenever the frequency is positive and no dissipation for negative frequencies. This allows us to use `sigmax()` ( a hermitian operator) instead of the non-hermitian operator `sigmam` used above.
@@ -83,7 +83,7 @@ a_op = [sigmax(), lambda w: gamma * (w > 0.0)]
 Instead of the `c_ops` we now pass the `a_ops` to the Bloch-Redfield solver.
 
 ```python
-result_brme = brmesolve(H, psi0, times, [a_op], e_ops)
+result_brme = brmesolve(H, psi0, times, [a_op], e_ops=e_ops)
 ```
 
 We can now compare the expectation values for every operator we passed to the solvers in `e_ops`. As expected both solvers, `mesolve` and `brmesolve`, produce similar results.

--- a/tutorials-v5/time-evolution/009_brmesolve-cavity-QED.md
+++ b/tutorials-v5/time-evolution/009_brmesolve-cavity-QED.md
@@ -93,8 +93,8 @@ We now solve the dynamics of the atom-cavity interaction using `qutip.mesolve` a
 # times for simulation
 times = np.linspace(0, 10 * 2 * np.pi / g_weak, 1000)
 # simulation
-result_me_weak = mesolve(H_weak, psi0, times, c_ops, e_ops)
-result_brme_weak = brmesolve(H_weak, psi0, times, a_ops, e_ops)
+result_me_weak = mesolve(H_weak, psi0, times, c_ops, e_ops=e_ops)
+result_brme_weak = brmesolve(H_weak, psi0, times, a_ops, e_ops=e_ops)
 fig, axes = plot_expectation_values(
     [result_me_weak, result_brme_weak], ylabels=["<n_cav>", "<n_atom>"]
 )
@@ -110,8 +110,8 @@ For the weak coupling strength between atom and cavity we obtain similar results
 # times for simulation
 times = np.linspace(0, 10 * 2 * np.pi / g_strong, 1000)
 # simulation
-result_me_strong = mesolve(H_strong, psi0, times, c_ops, e_ops)
-result_brme_strong = brmesolve(H_strong, psi0, times, a_ops, e_ops)
+result_me_strong = mesolve(H_strong, psi0, times, c_ops, e_ops=e_ops)
+result_brme_strong = brmesolve(H_strong, psi0, times, a_ops, e_ops=e_ops)
 fig, axes = plot_expectation_values(
     [result_me_strong, result_brme_strong], ylabels=["<n_cav>", "<n_atom>"]
 )

--- a/tutorials-v5/time-evolution/012_floquet_formalism.md
+++ b/tutorials-v5/time-evolution/012_floquet_formalism.md
@@ -186,6 +186,6 @@ about()
 
 ```python
 # compute prediction using sesolve
-res_sesolve = sesolve(H, psi0, tlist_10_periods, [num(2)])
+res_sesolve = sesolve(H, psi0, tlist_10_periods, e_ops=[num(2)])
 assert np.allclose(res_sesolve.expect[0], p_ex, atol=0.15)
 ```

--- a/tutorials-v5/time-evolution/013_nonmarkovian_monte_carlo.md
+++ b/tutorials-v5/time-evolution/013_nonmarkovian_monte_carlo.md
@@ -288,7 +288,7 @@ times_is = np.linspace(ti, ti + duration / 2, steps + 1)
 ntraj_is = int(ntraj / 10)
 
 MCSol_is = solver.run(psi0, tlist=times_is, ntraj=ntraj_is, e_ops=e_ops)
-MESol_is = qt.mesolve([H, S], psi0, times_is, d_ops, e_ops, options=options)
+MESol_is = qt.mesolve([H, S], psi0, times_is, d_ops, e_ops=e_ops, options=options)
 ```
 
 If we count the number of collapses per trajectory, we see that around 10% of the trajectories had no collapses:

--- a/tutorials-v5/time-evolution/015_smesolve-heterodyne.md
+++ b/tutorials-v5/time-evolution/015_smesolve-heterodyne.md
@@ -64,7 +64,7 @@ e_ops = [a.dag() * a, x, y]
 ```
 
 ```python
-result_ref = mesolve(H, rho0, times, c_ops, e_ops)
+result_ref = mesolve(H, rho0, times, c_ops, e_ops=e_ops)
 ```
 
 ```python

--- a/tutorials-v5/time-evolution/016_smesolve-inefficient-detection.md
+++ b/tutorials-v5/time-evolution/016_smesolve-inefficient-detection.md
@@ -106,7 +106,7 @@ sc_ops = [np.sqrt(eta) * np.sqrt(gamma) * a]  # stochastic collapse operator A
 ```
 
 ```python
-result_ref = mesolve(H, rho0, times, c_ops + sc_ops, e_ops)
+result_ref = mesolve(H, rho0, times, c_ops + sc_ops, e_ops=e_ops)
 ```
 
 ```python
@@ -169,7 +169,7 @@ sc_ops = [np.sqrt(eta) * np.sqrt(gamma) * a]  # stochastic collapse operator A
 ```
 
 ```python
-result_ref = mesolve(H, rho0, times, c_ops + sc_ops, e_ops)
+result_ref = mesolve(H, rho0, times, c_ops + sc_ops, e_ops=e_ops)
 ```
 
 ```python
@@ -251,7 +251,7 @@ sc_ops = [np.sqrt(eta) * np.sqrt(gamma) * a]  # stochastic collapse operator A
 ```
 
 ```python
-result_ref = mesolve(H, rho0, times, c_ops + sc_ops, e_ops)
+result_ref = mesolve(H, rho0, times, c_ops + sc_ops, e_ops=e_ops)
 ```
 
 ```python

--- a/tutorials-v5/time-evolution/017_smesolve-jc-photocurrent.md
+++ b/tutorials-v5/time-evolution/017_smesolve-jc-photocurrent.md
@@ -65,7 +65,7 @@ sc_ops = [np.sqrt(kappa) * a]  # stochastic collapse for resonator
 ```
 
 ```python
-result_ref = mesolve(H, rho0, times, c_ops + sc_ops, e_ops)
+result_ref = mesolve(H, rho0, times, c_ops + sc_ops, e_ops=e_ops)
 ```
 
 ```python

--- a/tutorials-v5/time-evolution/018_measures-trajectories-cats-kerr.md
+++ b/tutorials-v5/time-evolution/018_measures-trajectories-cats-kerr.md
@@ -236,7 +236,7 @@ sol_mc = mcsolve(
     fock(20, 0),
     tlist,
     c_ops,
-    [a.dag() * a, (a + a.dag()) / 2, -1.0j * (a - a.dag()) / 2, parity],
+    e_ops=[a.dag() * a, (a + a.dag()) / 2, -1.0j * (a - a.dag()) / 2, parity],
     ntraj=1,
 )
 ```

--- a/tutorials-v5/time-evolution/018_measures-trajectories-cats-kerr.md
+++ b/tutorials-v5/time-evolution/018_measures-trajectories-cats-kerr.md
@@ -370,7 +370,7 @@ sol_mc_mean = mcsolve(
     fock(20, 0),
     tlist,
     c_ops,
-    [a.dag() * a, (a + a.dag()) / 2, -1.0j * (a - a.dag()) / 2, parity],
+    e_ops=[a.dag() * a, (a + a.dag()) / 2, -1.0j * (a - a.dag()) / 2, parity],
     ntraj=50,
 )
 

--- a/tutorials-v5/time-evolution/020_homodyned-Jaynes-Cummings-emission.md
+++ b/tutorials-v5/time-evolution/020_homodyned-Jaynes-Cummings-emission.md
@@ -413,7 +413,13 @@ c_ops_TLS = [sm_TLS * np.sqrt(effective_gamma)]
 rho0_TLS = steadystate(H_TLS, c_ops_TLS)
 corr_vec_TLS = expect(
     sm_TLS.dag() * sm_TLS,
-    mesolve(H_TLS, sm_TLS * rho0_TLS * sm_TLS.dag(), taulist, c_ops_TLS, e_ops=[]).states,
+    mesolve(
+        H_TLS,
+        sm_TLS * rho0_TLS * sm_TLS.dag(),
+        taulist,
+        c_ops_TLS,
+        e_ops=[],
+    ).states,
 )
 n_TLS = expect(rho0_TLS, sm_TLS.dag() * sm_TLS)
 ```

--- a/tutorials-v5/time-evolution/020_homodyned-Jaynes-Cummings-emission.md
+++ b/tutorials-v5/time-evolution/020_homodyned-Jaynes-Cummings-emission.md
@@ -387,7 +387,7 @@ corr_vec_int = expect(
         (a + alpha) * rho0 * (a.dag() + alpha.conjugate()),
         taulist,
         c_op,
-        [],
+        e_ops=[],
         options={"atol": 1e-13, "rtol": 1e-11},
     ).states,
 )
@@ -401,7 +401,7 @@ corr_vec = expect(
         a * rho0 * a.dag(),
         taulist,
         c_op,
-        [],
+        e_ops=[],
         options={"atol": 1e-12, "rtol": 1e-10},
     ).states,
 )
@@ -413,7 +413,7 @@ c_ops_TLS = [sm_TLS * np.sqrt(effective_gamma)]
 rho0_TLS = steadystate(H_TLS, c_ops_TLS)
 corr_vec_TLS = expect(
     sm_TLS.dag() * sm_TLS,
-    mesolve(H_TLS, sm_TLS * rho0_TLS * sm_TLS.dag(), taulist, c_ops_TLS, []).states,
+    mesolve(H_TLS, sm_TLS * rho0_TLS * sm_TLS.dag(), taulist, c_ops_TLS, e_ops=[]).states,
 )
 n_TLS = expect(rho0_TLS, sm_TLS.dag() * sm_TLS)
 ```

--- a/tutorials-v5/time-evolution/020_homodyned-Jaynes-Cummings-emission.md
+++ b/tutorials-v5/time-evolution/020_homodyned-Jaynes-Cummings-emission.md
@@ -413,13 +413,7 @@ c_ops_TLS = [sm_TLS * np.sqrt(effective_gamma)]
 rho0_TLS = steadystate(H_TLS, c_ops_TLS)
 corr_vec_TLS = expect(
     sm_TLS.dag() * sm_TLS,
-    mesolve(
-        H_TLS,
-        sm_TLS * rho0_TLS * sm_TLS.dag(),
-        taulist,
-        c_ops_TLS,
-        e_ops=[],
-    ).states,
+    mesolve(H_TLS, sm_TLS * rho0_TLS * sm_TLS.dag(), taulist, c_ops_TLS).states,
 )
 n_TLS = expect(rho0_TLS, sm_TLS.dag() * sm_TLS)
 ```

--- a/tutorials-v5/time-evolution/021_quasi-steadystate-driven-system.md
+++ b/tutorials-v5/time-evolution/021_quasi-steadystate-driven-system.md
@@ -118,7 +118,7 @@ psi_1 = basis(2, 1)
 
 ```python
 # Solve with the Master equation
-output = mesolve(H, psi_0, t_list, c_op_list, [psi_1 * psi_1.dag()], args)
+output = mesolve(H, psi_0, t_list, c_op_list, e_ops=[psi_1 * psi_1.dag()], args=args)
 prob_me = output.expect[0]
 ```
 

--- a/tutorials-v5/time-evolution/024_v5_paper-mesolve.md
+++ b/tutorials-v5/time-evolution/024_v5_paper-mesolve.md
@@ -464,7 +464,7 @@ fit_times = np.linspace(0, 5, 1000)  # range for correlation function fit
 
 # Fit correlation function with exponentials
 exp_bath, fit_info = bath.approximate(
-    fit_times, Ni_max=1, Nr_max=2, target_rmse=None
+    "cf", fit_times, Ni_max=1, Nr_max=2, target_rmse=None
 )
 print(fit_info["summary"])
 ```
@@ -548,7 +548,7 @@ fit_times = np.linspace(0, 5, 1000)  # range for correlation function fit
 
 # Fit correlation function with exponentials
 exp_bath, fit_info = bath.approximate(
-    fit_times, Ni_max=1, Nr_max=2, target_rmse=None
+    "cf", fit_times, Ni_max=1, Nr_max=2, target_rmse=None
 )
 print(fit_info["summary"])
 ```

--- a/tutorials-v5/time-evolution/024_v5_paper-mesolve.md
+++ b/tutorials-v5/time-evolution/024_v5_paper-mesolve.md
@@ -463,7 +463,7 @@ bath = UnderDampedEnvironment(lam=lambd, w0=w0, gamma=gamma_heom, T=0)
 fit_times = np.linspace(0, 5, 1000)  # range for correlation function fit
 
 # Fit correlation function with exponentials
-exp_bath, fit_info = bath.approx_by_cf_fit(
+exp_bath, fit_info = bath.approximate(
     fit_times, Ni_max=1, Nr_max=2, target_rmse=None
 )
 print(fit_info["summary"])
@@ -547,7 +547,7 @@ bath = UnderDampedEnvironment(lam=lambd, w0=w0, gamma=gamma_heom, T=0)
 fit_times = np.linspace(0, 5, 1000)  # range for correlation function fit
 
 # Fit correlation function with exponentials
-exp_bath, fit_info = bath.approx_by_cf_fit(
+exp_bath, fit_info = bath.approximate(
     fit_times, Ni_max=1, Nr_max=2, target_rmse=None
 )
 print(fit_info["summary"])

--- a/tutorials-v5/visualization/JC-model-wigner-function.md
+++ b/tutorials-v5/visualization/JC-model-wigner-function.md
@@ -67,7 +67,7 @@ def jc_integrate(N, wc, wa, g, kappa, gamma, psi0, use_rwa, tlist):
         c_op_list.append(np.sqrt(rate) * sm)
 
     # evolve and calculate return state vectors
-    result = mesolve(H, psi0, tlist, c_op_list, [])
+    result = mesolve(H, psi0, tlist, c_op_list, e_ops=[])
 
     return result
 ```

--- a/tutorials-v5/visualization/animation-demo.md
+++ b/tutorials-v5/visualization/animation-demo.md
@@ -51,7 +51,7 @@ psi0 = (ket('10')+ket('01')).unit()
 # list of times for which the solver should store the state vector
 tlist = np.linspace(0, 3*np.pi, 100)
 
-results = mesolve(H, psi0, tlist, [], [])
+results = mesolve(H, psi0, tlist, [], e_ops=[])
 
 fig, ani = anim_schmidt(results)
 ```

--- a/tutorials-v5/visualization/bloch-sphere-animation.md
+++ b/tutorials-v5/visualization/bloch-sphere-animation.md
@@ -54,7 +54,7 @@ def qubit_integrate(w, theta, gamma1, gamma2, psi0, tlist):
         c_op_list.append(np.sqrt(rate) * sz)
 
     # evolve and calculate expectation values
-    output = mesolve(H, psi0, tlist, c_op_list, [sx, sy, sz])
+    output = mesolve(H, psi0, tlist, c_op_list, e_ops=[sx, sy, sz])
     return output
 ```
 

--- a/tutorials-v5/visualization/bloch_sphere_with_colorbar.md
+++ b/tutorials-v5/visualization/bloch_sphere_with_colorbar.md
@@ -42,7 +42,7 @@ expt_ops = [sm.dag() * sm, sx, sy, sz]
 
 
 tlist = np.linspace(-10.0, 10.0, 1500)
-expt_list = sesolve(H, psi0, tlist, expt_ops).expect
+expt_list = sesolve(H, psi0, tlist, e_ops=expt_ops).expect
 expt_list = [np.array(exp) for exp in expt_list]
 ```
 

--- a/tutorials-v5/visualization/visualization-exposition.md
+++ b/tutorials-v5/visualization/visualization-exposition.md
@@ -115,7 +115,7 @@ H = sigmaz() + 0.3 * sigmay()
 e_ops = [sigmax(), sigmay(), sigmaz()]
 times = np.linspace(0, 10, 100)
 psi0 = (basis(2, 0) + basis(2, 1)).unit()
-result = qt.mesolve(H, psi0, times, [], e_ops)
+result = qt.mesolve(H, psi0, times, [], e_ops=e_ops)
 ```
 
 ```python


### PR DESCRIPTION
- SolverOptions was deprecated in https://github.com/qutip/qutip/pull/1955 and removed in https://github.com/qutip/qutip/pull/2870
- The environment interface was changed in https://github.com/qutip/qutip/pull/2594
- e_ops were made keywords argument only in https://github.com/qutip/qutip/pull/2503

AI Usage: Copilot is used with GPT-5.3-Codex to scan and fix the errors