### PR TITLE
Fix the cache key for v5 release and master environment

### DIFF
--- a/.github/workflows/nightly_ci.yaml
+++ b/.github/workflows/nightly_ci.yaml
@@ -47,7 +47,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ env.CONDA }}/envs
-        key: conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ hashFiles('test_environment.yml') }}-${{ env.CACHE_NUMBER }}-qutip-${{ matrix.qutip-version }}
+        key: conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ hashFiles(format('test_environment-v{0}.yml', matrix.qutip-version)) }}-${{ env.CACHE_NUMBER }}-${{ matrix.label }}
       env:
         # Increase this value to reset cache if etc/example-environment.yml has not changed
         CACHE_NUMBER: 0

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -48,8 +48,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ env.CONDA }}/envs
-        key: conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ hashFiles('test_environment.yml') }}-${{ env.CACHE_NUMBER }}-qutip-${{ matrix.qutip-version }}
-      env:
+        key: conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ hashFiles(format('test_environment-v{0}.yml', matrix.qutip-version)) }}-${{ env.CACHE_NUMBER }}-${{ matrix.label }}
         # Increase this value to reset cache if etc/example-environment.yml has not changed
         CACHE_NUMBER: 0
       id: cache


### PR DESCRIPTION
**Description**
The conda environment cache key used `qutip-${{ matrix.qutip-version }}`, which evaluated to the same string `qutip-5` for both the `v5-release` and `v5-master` jobs. Because the conda cache stores the entire environment directory, including pip-installed packages, whichever job saved its cache last would set the qutip version for both jobs on subsequent runs. As a result, `qutip-v5-release` does not get its own environment but uses the `qutip-v5-master` env instead.

Changed the cache key suffix from qutip-${{ matrix.qutip-version }} to ${{ matrix.label }}, giving each job (v4-release, v5-release, v5-master) its own independent conda environment cache.