### PR TITLE
Update CI workflows for Node 24 GitHub Actions

### DIFF
--- a/.github/workflows/nightly_ci.yaml
+++ b/.github/workflows/nightly_ci.yaml
@@ -37,6 +37,8 @@ jobs:
       with:
         miniforge-version: latest
         activate-environment: test-environment-v${{ matrix.qutip-version }}
+        channels: conda-forge
+        conda-remove-defaults: "true"
 
     - name: Get Date
       id: get-date

--- a/.github/workflows/nightly_ci.yaml
+++ b/.github/workflows/nightly_ci.yaml
@@ -30,10 +30,10 @@ jobs:
             qip-install-spec: 'git+https://github.com/qutip/qutip-qip@master'
   
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v4
       with:
         miniforge-version: latest
         activate-environment: test-environment-v${{ matrix.qutip-version }}
@@ -44,7 +44,7 @@ jobs:
       shell: bash
 
     - name: Cache Conda env
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ${{ env.CONDA }}/envs
         key: conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ hashFiles(format('test_environment-v{0}.yml', matrix.qutip-version)) }}-${{ env.CACHE_NUMBER }}-${{ matrix.label }}
@@ -109,7 +109,7 @@ jobs:
       run: cp tutorials-v5/miscellaneous/cuQuantum_backend.ipynb notebooks/miscellaneous/
 
     - name: Create Notebook Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: executed-notebooks-${{ matrix.label }}
         path: |
@@ -119,7 +119,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: tcort/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
@@ -134,7 +134,7 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Open Issue on Failure
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/nightly_ci.yaml
+++ b/.github/workflows/nightly_ci.yaml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Get Date
       id: get-date
-      run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')"
+      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Cache Conda env

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -51,6 +51,7 @@ jobs:
       with:
         path: ${{ env.CONDA }}/envs
         key: conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ hashFiles(format('test_environment-v{0}.yml', matrix.qutip-version)) }}-${{ env.CACHE_NUMBER }}-${{ matrix.label }}
+      env:
         # Increase this value to reset cache if etc/example-environment.yml has not changed
         CACHE_NUMBER: 0
       id: cache

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -38,6 +38,8 @@ jobs:
       with:
         miniforge-version: latest
         activate-environment: test-environment-v${{ matrix.qutip-version }}
+        channels: conda-forge
+        conda-remove-defaults: "true"
 
     - name: Get Date
       id: get-date

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -31,10 +31,10 @@ jobs:
             qip-install-spec: 'git+https://github.com/qutip/qutip-qip@master'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v4
       with:
         miniforge-version: latest
         activate-environment: test-environment-v${{ matrix.qutip-version }}
@@ -45,7 +45,7 @@ jobs:
       shell: bash
 
     - name: Cache Conda env
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ${{ env.CONDA }}/envs
         key: conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ hashFiles(format('test_environment-v{0}.yml', matrix.qutip-version)) }}-${{ env.CACHE_NUMBER }}-${{ matrix.label }}
@@ -109,7 +109,7 @@ jobs:
       run: cp tutorials-v5/miscellaneous/cuQuantum_backend.ipynb notebooks/miscellaneous/
 
     - name: Create Notebook Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: executed-notebooks-${{ matrix.label }}
         path: |
@@ -119,7 +119,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: tcort/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
@@ -133,13 +133,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'qutip/qutip-tutorials' && github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v7
         with:
           name: executed-notebooks-v4-release
           path: publish/tutorials-v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: executed-notebooks-v5-release
           path: publish/tutorials-v5

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Get Date
       id: get-date
-      run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')"
+      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Cache Conda env


### PR DESCRIPTION
- Update GitHub Actions dependencies to Node 24-compatible versions.
- Configure `setup-miniconda` to use `conda-forge` only and remove the implicit `defaults` channel.
- Replace deprecated `set-output` usage with `$GITHUB_OUTPUT`.
- Move the notebook workflow cache number into the cache step environment.

The master branch failing is a qip test that we still need to fix...