### PR TITLE
Specify explicit versions of qutip-jax: master for v4 and v5-master, latest released for v5-release

### DIFF
--- a/.github/workflows/nightly_ci.yaml
+++ b/.github/workflows/nightly_ci.yaml
@@ -20,14 +20,17 @@ jobs:
             qutip-version: '4'
             qutip-install-spec: 'qutip==4.7.*'
             qip-install-spec: 'qutip-qip==0.4.*'
+            jax-install-spec: 'git+https://github.com/qutip/qutip-jax'
           - label: 'v5-release'
             qutip-version: '5'
             qutip-install-spec: 'qutip'
             qip-install-spec: 'qutip-qip'
+            jax-install-spec: 'qutip-jax==0.1.1'
           - label: 'v5-master'
             qutip-version: '5'
             qutip-install-spec: 'git+https://github.com/qutip/qutip@master'
             qip-install-spec: 'git+https://github.com/qutip/qutip-qip@master'
+            jax-install-spec: 'git+https://github.com/qutip/qutip-jax'
   
     steps:
     - uses: actions/checkout@v5
@@ -65,7 +68,7 @@ jobs:
         python -m pip install jax jax[cpu] equinox diffrax
         python -m pip install "${{ matrix.qutip-install-spec }}"
         python -m pip install "${{ matrix.qip-install-spec }}"
-        python -m pip install --no-deps git+https://github.com/qutip/qutip-jax
+        python -m pip install --no-deps "${{ matrix.jax-install-spec }}"
         python -m pip install --no-deps git+https://github.com/qutip/qutip-qtrl
         python -m pip install --no-deps git+https://github.com/qutip/qutip-qoc
 

--- a/.github/workflows/notebook_ci.yaml
+++ b/.github/workflows/notebook_ci.yaml
@@ -21,14 +21,17 @@ jobs:
             qutip-version: '4'
             qutip-install-spec: 'qutip==4.*'
             qip-install-spec: 'qutip-qip==0.4.*'
+            jax-install-spec: 'git+https://github.com/qutip/qutip-jax'
           - label: 'v5-release'
             qutip-version: '5'
             qutip-install-spec: 'qutip'
             qip-install-spec: 'qutip-qip'
+            jax-install-spec: 'qutip-jax==0.1.1'
           - label: 'v5-master'
             qutip-version: '5'
             qutip-install-spec: 'git+https://github.com/qutip/qutip@master'
             qip-install-spec: 'git+https://github.com/qutip/qutip-qip@master'
+            jax-install-spec: 'git+https://github.com/qutip/qutip-jax'
 
     steps:
     - uses: actions/checkout@v5
@@ -66,7 +69,7 @@ jobs:
         python -m pip install "jax<0.7.0" "jax[cpu]<0.7.0" equinox diffrax
         python -m pip install "${{ matrix.qutip-install-spec }}"
         python -m pip install "${{ matrix.qip-install-spec }}"
-        python -m pip install --no-deps git+https://github.com/qutip/qutip-jax
+        python -m pip install --no-deps "${{ matrix.jax-install-spec }}"
         python -m pip install --no-deps git+https://github.com/qutip/qutip-qtrl
         python -m pip install --no-deps git+https://github.com/qutip/qutip-qoc
 


### PR DESCRIPTION
# Description

This fixes the import error in nightly and regular runs for `v5-release`: 

```
File ~/miniconda3/envs/test-environment-v5/lib/python3.12/site-packages/qutip_jax/einsum.py:4
      2 import jax.numpy as jnp
      3 import numpy as np
----> 4 from qutip.core.data import einsum
      5 from qutip.core.data.convert import to as _to
      6 from .jaxarray import JaxArray

ImportError: cannot import name 'einsum' from 'qutip.core.data' (/home/runner/miniconda3/envs/test-environment-v5/lib/python3.12/site-packages/qutip/core/data/__init__.py)
```
It is correct to pin `qutip-jax` to the released version too since `qutip-jax`'s master currently requires changes that are not released in `qutip` yet. 

Additionally, the `qutip-jax`'s version is now more visible in the worfklow config for those jobs that don't fail.

# Note

Tests keep to fail, though, there is a tolerance error in `time-evolution/024_v5_paper-mesolve.ipynb` for both `v5-release` and `v5-master`. It has been there before the import error and has to be tackled in another PR. 